### PR TITLE
feat!: extend DTO resolver/validation with group sequence providers and nested DTO arrays

### DIFF
--- a/README.md
+++ b/README.md
@@ -33,7 +33,7 @@ Register the bundle in your Symfony application. Add the following to your `conf
 ```php
 return [
     // other bundles
-    Crtl\RequestDTOResolverBundle\CrtlRequestDTOResolverBundle::class => ["all" => true],
+    Crtl\RequestDtoResolverBundle\CrtlRequestDTOResolverBundle::class => ["all" => true],
 ];
 ```
 
@@ -47,12 +47,12 @@ Annotate the class with [`#[RequestDto]`](src/Attribute/RequestDto.php) and use 
 ```php
 namespace App\DTO;
 
-use Crtl\RequestDTOResolverBundle\Attribute\BodyParam;
-use Crtl\RequestDTOResolverBundle\Attribute\FileParam;
-use Crtl\RequestDTOResolverBundle\Attribute\HeaderParam;
-use Crtl\RequestDTOResolverBundle\Attribute\QueryParam;
-use Crtl\RequestDTOResolverBundle\Attribute\RouteParam;
-use Crtl\RequestDTOResolverBundle\Attribute\RequestDto;
+use Crtl\RequestDtoResolverBundle\Attribute\BodyParam;
+use Crtl\RequestDtoResolverBundle\Attribute\FileParam;
+use Crtl\RequestDtoResolverBundle\Attribute\HeaderParam;
+use Crtl\RequestDtoResolverBundle\Attribute\QueryParam;
+use Crtl\RequestDtoResolverBundle\Attribute\RouteParam;
+use Crtl\RequestDtoResolverBundle\Attribute\RequestDto;
 use Symfony\Component\HttpFoundation\Request;
 use Symfony\Component\Validator\Constraints as Assert;
 
@@ -83,7 +83,7 @@ class ExampleDTO
     public string $id;
     
     // Nested DTOs are supported for BodyParam and QueryParam
-    #[BodyParam("nested"), Assert\Valid]
+    #[BodyParam("nested")] // Dont use Assert\Valid on nested DTOs otherwise native validation is triggered
     public ?NestedRequestDTO $nestedBodyDto;
     
     // Optionally implement constructor which accepts request object
@@ -96,6 +96,9 @@ class ExampleDTO
 
 > **IMPORTANT: Strict Typing**<br/>
 > While strict types are supported, validation constraint mismatches can still lead to `TypeError` in production. Always ensure your constraints (e.g., `Assert\Type`, `Assert\NotBlank`) match your property types.
+
+> > **IMPORTANT: Nested DTOs**<br/>
+> Dont use any assertions on nested DTO properties as this will trigger the native validation fow eventually breaking hydration and triggering errors.
 
 ### DTO Lifecycle
 
@@ -126,18 +129,128 @@ class ExampleController extends AbstractController
 }
 ```
 
+### Using RequestDtoTrait
+
+The [`RequestDtoTrait`](src/Trait/RequestDtoTrait.php) provides a default constructor that accepts the `Request` object and a `getValue(string $property)` method. This method is useful for accessing request data before hydration, which can come in handy in group sequence providers.
+
+```php
+use Crtl\RequestDtoResolverBundle\Attribute\RequestDto;
+use Crtl\RequestDtoResolverBundle\Trait\RequestDtoTrait;
+use Crtl\RequestDtoResolverBundle\Attribute\BodyParam;
+
+#[RequestDto]
+class MyDTO
+{
+    use RequestDtoTrait;
+
+    #[BodyParam]
+    public string $type;
+}
+```
+
+### Validation Group Sequences
+
+When using [Group Sequences](https://symfony.com/doc/current/validation/sequence_provider.html) to define conditional validation, you must be careful about how you access data.
+
+**IMPORTANT: Uninitialized Properties**
+
+Since hydration happens *after* validation, DTO properties are **uninitialized** when the group sequence is evaluated. Accessing them directly will throw an `Error`.
+
+To safely access request parameters in your group sequence logic, use `RequestDtoTrait::getValue()`:
+
+```php
+use Crtl\RequestDtoResolverBundle\Attribute\RequestDto;
+use Crtl\RequestDtoResolverBundle\Trait\RequestDtoTrait;
+use Symfony\Component\Validator\Constraints\GroupSequence;
+use Symfony\Component\Validator\GroupSequenceProviderInterface;
+
+#[RequestDto]
+class MyDTO implements GroupSequenceProviderInterface
+{
+    use RequestDtoTrait;
+
+    #[BodyParam]
+    public string $type;
+
+    public function getGroupSequence(): array|GroupSequence
+    {
+        // Use getValue() instead of $this->type
+        $type = $this->getValue("type");
+
+        $groups = ["MyDTO"];
+        if ($type === "special") {
+            $groups[] = "Special";
+        }
+
+        return $groups;
+    }
+}
+```
+
+#### Using a Group Sequence Provider Service
+
+You can also use a service to provide the group sequence. This is useful if your validation logic depends on external services (e.g., a database or configuration).
+
+1. **Create the Provider Service**:
+
+```php
+namespace App\Validator;
+
+use App\DTO\MyDTO;
+use Symfony\Component\Validator\Constraints\GroupSequence;
+use Symfony\Component\Validator\GroupProviderInterface;
+
+class MyGroupSequenceProvider implements GroupProviderInterface
+{
+    public function getGroups(object $object): array|GroupSequence
+    {
+        assert($object instanceof MyDTO)
+    
+        $groups = ["MyDTO"];
+
+        // Use getValue() to safely access uninitialized properties
+        if ($object->getValue("type") === "special") {
+            $groups[] = "Special";
+        }
+
+        return $groups;
+    }
+}
+```
+
+2. **Configure the DTO**:
+
+```php
+use App\Validator\MyGroupSequenceProvider;
+use Crtl\RequestDtoResolverBundle\Attribute\RequestDto;
+use Crtl\RequestDtoResolverBundle\Trait\RequestDtoTrait;
+use Symfony\Component\Validator\Constraints as Assert;
+
+#[RequestDto]
+#[Assert\GroupSequenceProvider(provider: MyGroupSequenceProvider::class)]
+class MyDTO
+{
+    // Trait is important to access fields before validation
+    use RequestDtoTrait;
+    
+    // ...
+}
+```
+
+> **Note**: `getValue()` only works in **root DTOs**. It uses reflection to resolve data from the request, which cannot access parent data in nested contexts.
+
 ### Step 3: Handle Validation Errors
 
-When validation fails, a [`Crtl\RequestDTOResolverBundle\Exception\RequestValidationException`](src/Exception/RequestValidationException.php) is thrown.
+When validation fails, a [`Crtl\RequestDtoResolverBundle\Exception\RequestValidationException`](src/Exception/RequestValidationException.php) is thrown.
 
-The bundle registers a default exception subscriber ([`RequestValidationExceptionEventSubscriber`](src/EventSubscriber/RequestValidationExceptionEventSubscriber.php)) with a low priority of **-1024**. This ensures that validation exceptions are caught and converted into a `JsonResponse` with a `400 Bad Request` status code by default.
+The bundle registers a default exception subscriber ([`RequestValidationExceptionEventSubscriber`](src/EventSubscriber/RequestValidationExceptionEventSubscriber.php)) with a low priority of **-32**. This ensures that validation exceptions are caught and converted into a `JsonResponse` with a `400 Bad Request` status code by default.
 
 You can still provide your own listener if you need custom error formatting:
 
 ```php
 namespace App\EventListener;
 
-use Crtl\RequestDTOResolverBundle\Exception\RequestValidationException;
+use Crtl\RequestDtoResolverBundle\Exception\RequestValidationException;
 use Symfony\Component\EventDispatcher\EventSubscriberInterface;
 use Symfony\Component\HttpFoundation\JsonResponse;
 use Symfony\Component\HttpKernel\Event\ExceptionEvent;
@@ -148,7 +261,7 @@ class RequestValidationExceptionListener implements EventSubscriberInterface
     public static function getSubscribedEvents(): array
     {
         return [
-            // Use a priority > -1024 to override the default bundle subscriber
+            // Use a priority > -32 to override the default bundle subscriber
             KernelEvents::EXCEPTION => ["onKernelException", 0],
         ];
     }

--- a/composer.json
+++ b/composer.json
@@ -17,7 +17,8 @@
         "symfony/property-info": "^7.2 | ^8.0",
         "symfony/cache": "^7.1 | ^8.0",
         "symfony/framework-bundle": "^7.1 | ^8.0",
-        "psr/log": "^3.0"
+        "psr/log": "^3.0",
+        "phpdocumentor/reflection-docblock": "^5.6"
     },
     "require-dev": {
         "phpunit/phpunit": "^10",
@@ -35,18 +36,18 @@
     },
     "scripts": {
         "php-cs-fixer": "vendor/bin/php-cs-fixer fix",
-        "phpstan": "vendor/bin/phpstan analyse src test",
+        "phpstan": "vendor/bin/phpstan analyse --memory-limit=-1 src test",
         "coverage": " php -dxdebug.mode=coverage vendor/bin/phpunit --coverage-clover clover.xml",
         "coverage-badge": "vendor/bin/php-coverage-badger coverage.xml coverage.svg"
     },
     "autoload": {
         "psr-4": {
-            "Crtl\\RequestDTOResolverBundle\\": "src/"
+            "Crtl\\RequestDtoResolverBundle\\": "src/"
         }
     },
     "autoload-dev": {
         "psr-4": {
-            "Crtl\\RequestDTOResolverBundle\\Test\\": "test/"
+            "Crtl\\RequestDtoResolverBundle\\Test\\": "test/"
         }
     }
 }

--- a/composer.lock
+++ b/composer.lock
@@ -4,8 +4,278 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "5f852a32fa94d44321902ae72284ca38",
+    "content-hash": "0a040eb5b831da770f03701761d8be4c",
     "packages": [
+        {
+            "name": "doctrine/deprecations",
+            "version": "1.1.5",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/doctrine/deprecations.git",
+                "reference": "459c2f5dd3d6a4633d3b5f46ee2b1c40f57d3f38"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/doctrine/deprecations/zipball/459c2f5dd3d6a4633d3b5f46ee2b1c40f57d3f38",
+                "reference": "459c2f5dd3d6a4633d3b5f46ee2b1c40f57d3f38",
+                "shasum": ""
+            },
+            "require": {
+                "php": "^7.1 || ^8.0"
+            },
+            "conflict": {
+                "phpunit/phpunit": "<=7.5 || >=13"
+            },
+            "require-dev": {
+                "doctrine/coding-standard": "^9 || ^12 || ^13",
+                "phpstan/phpstan": "1.4.10 || 2.1.11",
+                "phpstan/phpstan-phpunit": "^1.0 || ^2",
+                "phpunit/phpunit": "^7.5 || ^8.5 || ^9.6 || ^10.5 || ^11.5 || ^12",
+                "psr/log": "^1 || ^2 || ^3"
+            },
+            "suggest": {
+                "psr/log": "Allows logging deprecations via PSR-3 logger implementation"
+            },
+            "type": "library",
+            "autoload": {
+                "psr-4": {
+                    "Doctrine\\Deprecations\\": "src"
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "description": "A small layer on top of trigger_error(E_USER_DEPRECATED) or PSR-3 logging with options to disable all deprecations or selectively for packages.",
+            "homepage": "https://www.doctrine-project.org/",
+            "support": {
+                "issues": "https://github.com/doctrine/deprecations/issues",
+                "source": "https://github.com/doctrine/deprecations/tree/1.1.5"
+            },
+            "time": "2025-04-07T20:06:18+00:00"
+        },
+        {
+            "name": "phpdocumentor/reflection-common",
+            "version": "2.2.0",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/phpDocumentor/ReflectionCommon.git",
+                "reference": "1d01c49d4ed62f25aa84a747ad35d5a16924662b"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/phpDocumentor/ReflectionCommon/zipball/1d01c49d4ed62f25aa84a747ad35d5a16924662b",
+                "reference": "1d01c49d4ed62f25aa84a747ad35d5a16924662b",
+                "shasum": ""
+            },
+            "require": {
+                "php": "^7.2 || ^8.0"
+            },
+            "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-2.x": "2.x-dev"
+                }
+            },
+            "autoload": {
+                "psr-4": {
+                    "phpDocumentor\\Reflection\\": "src/"
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "Jaap van Otterdijk",
+                    "email": "opensource@ijaap.nl"
+                }
+            ],
+            "description": "Common reflection classes used by phpdocumentor to reflect the code structure",
+            "homepage": "http://www.phpdoc.org",
+            "keywords": [
+                "FQSEN",
+                "phpDocumentor",
+                "phpdoc",
+                "reflection",
+                "static analysis"
+            ],
+            "support": {
+                "issues": "https://github.com/phpDocumentor/ReflectionCommon/issues",
+                "source": "https://github.com/phpDocumentor/ReflectionCommon/tree/2.x"
+            },
+            "time": "2020-06-27T09:03:43+00:00"
+        },
+        {
+            "name": "phpdocumentor/reflection-docblock",
+            "version": "5.6.6",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/phpDocumentor/ReflectionDocBlock.git",
+                "reference": "5cee1d3dfc2d2aa6599834520911d246f656bcb8"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/phpDocumentor/ReflectionDocBlock/zipball/5cee1d3dfc2d2aa6599834520911d246f656bcb8",
+                "reference": "5cee1d3dfc2d2aa6599834520911d246f656bcb8",
+                "shasum": ""
+            },
+            "require": {
+                "doctrine/deprecations": "^1.1",
+                "ext-filter": "*",
+                "php": "^7.4 || ^8.0",
+                "phpdocumentor/reflection-common": "^2.2",
+                "phpdocumentor/type-resolver": "^1.7",
+                "phpstan/phpdoc-parser": "^1.7|^2.0",
+                "webmozart/assert": "^1.9.1 || ^2"
+            },
+            "require-dev": {
+                "mockery/mockery": "~1.3.5 || ~1.6.0",
+                "phpstan/extension-installer": "^1.1",
+                "phpstan/phpstan": "^1.8",
+                "phpstan/phpstan-mockery": "^1.1",
+                "phpstan/phpstan-webmozart-assert": "^1.2",
+                "phpunit/phpunit": "^9.5",
+                "psalm/phar": "^5.26"
+            },
+            "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-master": "5.x-dev"
+                }
+            },
+            "autoload": {
+                "psr-4": {
+                    "phpDocumentor\\Reflection\\": "src"
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "Mike van Riel",
+                    "email": "me@mikevanriel.com"
+                },
+                {
+                    "name": "Jaap van Otterdijk",
+                    "email": "opensource@ijaap.nl"
+                }
+            ],
+            "description": "With this component, a library can provide support for annotations via DocBlocks or otherwise retrieve information that is embedded in a DocBlock.",
+            "support": {
+                "issues": "https://github.com/phpDocumentor/ReflectionDocBlock/issues",
+                "source": "https://github.com/phpDocumentor/ReflectionDocBlock/tree/5.6.6"
+            },
+            "time": "2025-12-22T21:13:58+00:00"
+        },
+        {
+            "name": "phpdocumentor/type-resolver",
+            "version": "1.12.0",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/phpDocumentor/TypeResolver.git",
+                "reference": "92a98ada2b93d9b201a613cb5a33584dde25f195"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/phpDocumentor/TypeResolver/zipball/92a98ada2b93d9b201a613cb5a33584dde25f195",
+                "reference": "92a98ada2b93d9b201a613cb5a33584dde25f195",
+                "shasum": ""
+            },
+            "require": {
+                "doctrine/deprecations": "^1.0",
+                "php": "^7.3 || ^8.0",
+                "phpdocumentor/reflection-common": "^2.0",
+                "phpstan/phpdoc-parser": "^1.18|^2.0"
+            },
+            "require-dev": {
+                "ext-tokenizer": "*",
+                "phpbench/phpbench": "^1.2",
+                "phpstan/extension-installer": "^1.1",
+                "phpstan/phpstan": "^1.8",
+                "phpstan/phpstan-phpunit": "^1.1",
+                "phpunit/phpunit": "^9.5",
+                "rector/rector": "^0.13.9",
+                "vimeo/psalm": "^4.25"
+            },
+            "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-1.x": "1.x-dev"
+                }
+            },
+            "autoload": {
+                "psr-4": {
+                    "phpDocumentor\\Reflection\\": "src"
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "Mike van Riel",
+                    "email": "me@mikevanriel.com"
+                }
+            ],
+            "description": "A PSR-5 based resolver of Class names, Types and Structural Element Names",
+            "support": {
+                "issues": "https://github.com/phpDocumentor/TypeResolver/issues",
+                "source": "https://github.com/phpDocumentor/TypeResolver/tree/1.12.0"
+            },
+            "time": "2025-11-21T15:09:14+00:00"
+        },
+        {
+            "name": "phpstan/phpdoc-parser",
+            "version": "2.3.2",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/phpstan/phpdoc-parser.git",
+                "reference": "a004701b11273a26cd7955a61d67a7f1e525a45a"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/phpstan/phpdoc-parser/zipball/a004701b11273a26cd7955a61d67a7f1e525a45a",
+                "reference": "a004701b11273a26cd7955a61d67a7f1e525a45a",
+                "shasum": ""
+            },
+            "require": {
+                "php": "^7.4 || ^8.0"
+            },
+            "require-dev": {
+                "doctrine/annotations": "^2.0",
+                "nikic/php-parser": "^5.3.0",
+                "php-parallel-lint/php-parallel-lint": "^1.2",
+                "phpstan/extension-installer": "^1.0",
+                "phpstan/phpstan": "^2.0",
+                "phpstan/phpstan-phpunit": "^2.0",
+                "phpstan/phpstan-strict-rules": "^2.0",
+                "phpunit/phpunit": "^9.6",
+                "symfony/process": "^5.2"
+            },
+            "type": "library",
+            "autoload": {
+                "psr-4": {
+                    "PHPStan\\PhpDocParser\\": [
+                        "src/"
+                    ]
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "description": "PHPDoc parser with support for nullable, intersection and generic types",
+            "support": {
+                "issues": "https://github.com/phpstan/phpdoc-parser/issues",
+                "source": "https://github.com/phpstan/phpdoc-parser/tree/2.3.2"
+            },
+            "time": "2026-01-25T14:56:51+00:00"
+        },
         {
             "name": "psr/cache",
             "version": "3.0.0",
@@ -2496,6 +2766,68 @@
                 }
             ],
             "time": "2025-11-05T18:53:00+00:00"
+        },
+        {
+            "name": "webmozart/assert",
+            "version": "2.1.2",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/webmozarts/assert.git",
+                "reference": "ce6a2f100c404b2d32a1dd1270f9b59ad4f57649"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/webmozarts/assert/zipball/ce6a2f100c404b2d32a1dd1270f9b59ad4f57649",
+                "reference": "ce6a2f100c404b2d32a1dd1270f9b59ad4f57649",
+                "shasum": ""
+            },
+            "require": {
+                "ext-ctype": "*",
+                "ext-date": "*",
+                "ext-filter": "*",
+                "php": "^8.2"
+            },
+            "suggest": {
+                "ext-intl": "",
+                "ext-simplexml": "",
+                "ext-spl": ""
+            },
+            "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-feature/2-0": "2.0-dev"
+                }
+            },
+            "autoload": {
+                "psr-4": {
+                    "Webmozart\\Assert\\": "src/"
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "Bernhard Schussek",
+                    "email": "bschussek@gmail.com"
+                },
+                {
+                    "name": "Woody Gilk",
+                    "email": "woody.gilk@gmail.com"
+                }
+            ],
+            "description": "Assertions to validate method input/output with nice error messages.",
+            "keywords": [
+                "assert",
+                "check",
+                "validate"
+            ],
+            "support": {
+                "issues": "https://github.com/webmozarts/assert/issues",
+                "source": "https://github.com/webmozarts/assert/tree/2.1.2"
+            },
+            "time": "2026-01-13T14:02:24+00:00"
         }
     ],
     "packages-dev": [
@@ -6041,5 +6373,5 @@
         "php": ">=8.2"
     },
     "platform-dev": {},
-    "plugin-api-version": "2.9.0"
+    "plugin-api-version": "2.6.0"
 }

--- a/config/services.php
+++ b/config/services.php
@@ -13,14 +13,20 @@ declare(strict_types=1);
 
 namespace Symfony\Component\DependencyInjection\Loader\Configurator;
 
-use Crtl\RequestDTOResolverBundle\EventSubscriber\RequestDtoValidationEventSubscriber;
-use Crtl\RequestDTOResolverBundle\Reflection\RequestDtoMetadataFactory;
-use Crtl\RequestDTOResolverBundle\Reflection\RequestDtoParamMetadataFactory;
-use Crtl\RequestDTOResolverBundle\RequestDtoResolver;
-use Crtl\RequestDTOResolverBundle\Utility\DtoInstanceBag;
-use Crtl\RequestDTOResolverBundle\Utility\DtoInstanceBagInterface;
-use Crtl\RequestDTOResolverBundle\Utility\DtoReflectionHelper;
-use Crtl\RequestDTOResolverBundle\Validator\RequestDtoValidator;
+use Crtl\RequestDtoResolverBundle\EventSubscriber\RequestDtoValidationEventSubscriber;
+use Crtl\RequestDtoResolverBundle\EventSubscriber\RequestValidationExceptionEventSubscriber;
+use Crtl\RequestDtoResolverBundle\PropertyInfo\PropertyInfoExtractorFactory;
+use Crtl\RequestDtoResolverBundle\Reflection\RequestDtoMetadataFactory;
+use Crtl\RequestDtoResolverBundle\Reflection\RequestDtoParamMetadataFactory;
+use Crtl\RequestDtoResolverBundle\RequestDtoResolver;
+use Crtl\RequestDtoResolverBundle\Utility\DtoInstanceBag;
+use Crtl\RequestDtoResolverBundle\Utility\DtoInstanceBagInterface;
+use Crtl\RequestDtoResolverBundle\Utility\DtoReflectionHelper;
+use Crtl\RequestDtoResolverBundle\Validator\GroupSequenceExtractor;
+use Crtl\RequestDtoResolverBundle\Validator\RequestDtoValidator;
+use Symfony\Component\PropertyInfo\Extractor\PhpDocExtractor;
+use Symfony\Component\PropertyInfo\Extractor\ReflectionExtractor;
+use Symfony\Component\PropertyInfo\PropertyInfoExtractorInterface;
 
 return static function (ContainerConfigurator $container): void {
     $services = $container->services();
@@ -37,10 +43,37 @@ return static function (ContainerConfigurator $container): void {
 
     $services->alias(DtoInstanceBagInterface::class, DtoInstanceBag::class);
 
+    $services->set(GroupSequenceExtractor::class)
+        ->args([
+            '$groupProviderLocator' => service('service_container'),
+        ])
+        ->private();
+
+    $services->set(ReflectionExtractor::class)
+        ->private();
+
+    $services->set(PhpDocExtractor::class)
+        ->private();
+
+    $services->set(PropertyInfoExtractorFactory::class)
+        ->args([
+            '$reflectionExtractor' => service(ReflectionExtractor::class),
+            '$phpDocExtractor' => service(PhpDocExtractor::class),
+        ])
+    ;
+
+    // Bundle-specific PropertyInfo service (does NOT replace the app's global "property_info")
+    $services->set('crtl_request_dto_resolver_bundle.property_extractor', PropertyInfoExtractorInterface::class)
+        ->factory([
+            service(PropertyInfoExtractorFactory::class),
+            'create'
+        ]);
+
     $services->set(RequestDtoParamMetadataFactory::class)
         ->args([
             '$validator' => service('validator'),
             '$reflectionHelper' => service(DtoReflectionHelper::class),
+            '$propertyInfoExtractor' => service('crtl_request_dto_resolver_bundle.property_extractor'),
         ]);
 
     $services->set(RequestDtoMetadataFactory::class)
@@ -55,6 +88,7 @@ return static function (ContainerConfigurator $container): void {
         ->args([
             '$validator' => service('validator'),
             '$metadataFactory' => service(RequestDtoMetadataFactory::class),
+            '$groupSequenceExtractor' => service(GroupSequenceExtractor::class),
         ]);
 
     $services->set(RequestDtoResolver::class)
@@ -70,5 +104,8 @@ return static function (ContainerConfigurator $container): void {
             '$validator' => service(RequestDtoValidator::class),
             '$dtoInstanceBag' => service(DtoInstanceBagInterface::class),
         ])
+        ->tag('kernel.event_subscriber');
+
+    $services->set(RequestValidationExceptionEventSubscriber::class)
         ->tag('kernel.event_subscriber');
 };

--- a/config/services_test.php
+++ b/config/services_test.php
@@ -1,0 +1,25 @@
+<?php
+
+/*
+ * This file is part of a private project.
+ *
+ * Copyright 2026 Crtl
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+declare(strict_types=1);
+
+use Crtl\RequestDtoResolverBundle\PropertyInfo\PropertyInfoExtractorFactory;
+use Symfony\Component\DependencyInjection\Loader\Configurator\ContainerConfigurator;
+
+return static function (ContainerConfigurator $container): void {
+    $services = $container->services();
+
+    $services->get(PropertyInfoExtractorFactory::class)
+        ->public();
+
+    $services->set(Crtl\RequestDtoResolverBundle\Test\Fixtures\GroupProvider\TestGroupProvider::class)
+        ->public();
+};

--- a/phpunit.xml.dist
+++ b/phpunit.xml.dist
@@ -12,7 +12,7 @@
 >
 
     <php>
-        <server name="KERNEL_CLASS" value="Crtl\RequestDTOResolverBundle\Test\TestKernel" />
+        <server name="KERNEL_CLASS" value="Crtl\RequestDtoResolverBundle\Test\TestKernel" />
         <ini name="display_errors" value="Off"/> <!-- Set to Off to prevent recursive output loops -->
         <ini name="error_reporting" value="-1"/>
         <ini name="memory_limit" value="512M" />

--- a/src/Attribute/AbstractNestedParam.php
+++ b/src/Attribute/AbstractNestedParam.php
@@ -11,7 +11,7 @@
 
 declare(strict_types=1);
 
-namespace Crtl\RequestDTOResolverBundle\Attribute;
+namespace Crtl\RequestDtoResolverBundle\Attribute;
 
 use Symfony\Component\HttpFoundation\ParameterBag;
 use Symfony\Component\HttpFoundation\Request;
@@ -21,7 +21,19 @@ use Symfony\Component\HttpFoundation\Request;
  */
 abstract class AbstractNestedParam extends AbstractParam
 {
+    protected ?int $index = null;
+
     abstract protected function getInputBag(Request $request): ParameterBag;
+
+    public function setIndex(int $index): void
+    {
+        $this->index = $index;
+    }
+
+    public function getIndex(): ?int
+    {
+        return $this->index;
+    }
 
     /**
      * @return array<string, mixed>
@@ -33,15 +45,20 @@ abstract class AbstractNestedParam extends AbstractParam
 
     public function getValueFromRequest(Request $request): mixed
     {
-        $data = $this->getDataFromRequest($request);
-
         $name = $this->getName();
-        $parentName = $this->parent?->getName();
 
-        $value = $data[$parentName ?? $name] ?? null;
+        if ($this->parent) {
+            $data = $this->parent->getValueFromRequest($request);
+        } else {
+            $data = $this->getDataFromRequest($request);
+        }
 
-        if ($parentName) {
-            $value = is_array($value) && isset($value[$name]) ? $value[$name] : null;
+        $value = $data[$name] ?? null;
+
+        $index = $this->getIndex();
+
+        if (null !== $index) {
+            $value = is_array($value) && isset($value[$index]) ? $value[$index] : null;
         }
 
         return $value;

--- a/src/Attribute/AbstractParam.php
+++ b/src/Attribute/AbstractParam.php
@@ -11,7 +11,7 @@
 
 declare(strict_types=1);
 
-namespace Crtl\RequestDTOResolverBundle\Attribute;
+namespace Crtl\RequestDtoResolverBundle\Attribute;
 
 use ReflectionProperty;
 use Symfony\Component\HttpFoundation\Request;

--- a/src/Attribute/BodyParam.php
+++ b/src/Attribute/BodyParam.php
@@ -11,7 +11,7 @@
 
 declare(strict_types=1);
 
-namespace Crtl\RequestDTOResolverBundle\Attribute;
+namespace Crtl\RequestDtoResolverBundle\Attribute;
 
 use Attribute;
 use Symfony\Component\HttpFoundation\ParameterBag;

--- a/src/Attribute/FileParam.php
+++ b/src/Attribute/FileParam.php
@@ -11,7 +11,7 @@
 
 declare(strict_types=1);
 
-namespace Crtl\RequestDTOResolverBundle\Attribute;
+namespace Crtl\RequestDtoResolverBundle\Attribute;
 
 use Attribute;
 use Symfony\Component\HttpFoundation\File\UploadedFile;

--- a/src/Attribute/HeaderParam.php
+++ b/src/Attribute/HeaderParam.php
@@ -11,7 +11,7 @@
 
 declare(strict_types=1);
 
-namespace Crtl\RequestDTOResolverBundle\Attribute;
+namespace Crtl\RequestDtoResolverBundle\Attribute;
 
 use Attribute;
 use Symfony\Component\HttpFoundation\Request;

--- a/src/Attribute/QueryParam.php
+++ b/src/Attribute/QueryParam.php
@@ -11,7 +11,7 @@
 
 declare(strict_types=1);
 
-namespace Crtl\RequestDTOResolverBundle\Attribute;
+namespace Crtl\RequestDtoResolverBundle\Attribute;
 
 use Attribute;
 use Symfony\Component\HttpFoundation\ParameterBag;

--- a/src/Attribute/RequestDto.php
+++ b/src/Attribute/RequestDto.php
@@ -11,9 +11,9 @@
 
 declare(strict_types=1);
 
-namespace Crtl\RequestDTOResolverBundle\Attribute;
+namespace Crtl\RequestDtoResolverBundle\Attribute;
 
-use Crtl\RequestDTOResolverBundle\RequestDtoResolver;
+use Crtl\RequestDtoResolverBundle\RequestDtoResolver;
 
 /**
  * Marks a class as request DTO which will be resolved and validated

--- a/src/Attribute/RouteParam.php
+++ b/src/Attribute/RouteParam.php
@@ -11,7 +11,7 @@
 
 declare(strict_types=1);
 
-namespace Crtl\RequestDTOResolverBundle\Attribute;
+namespace Crtl\RequestDtoResolverBundle\Attribute;
 
 use Attribute;
 use Symfony\Component\HttpFoundation\Request;

--- a/src/EventSubscriber/RequestDtoValidationEventSubscriber.php
+++ b/src/EventSubscriber/RequestDtoValidationEventSubscriber.php
@@ -11,12 +11,12 @@
 
 declare(strict_types=1);
 
-namespace Crtl\RequestDTOResolverBundle\EventSubscriber;
+namespace Crtl\RequestDtoResolverBundle\EventSubscriber;
 
-use Crtl\RequestDTOResolverBundle\Exception\RequestValidationException;
-use Crtl\RequestDTOResolverBundle\RequestDtoResolver;
-use Crtl\RequestDTOResolverBundle\Utility\DtoInstanceBagInterface;
-use Crtl\RequestDTOResolverBundle\Validator\RequestDtoValidator;
+use Crtl\RequestDtoResolverBundle\Exception\RequestValidationException;
+use Crtl\RequestDtoResolverBundle\RequestDtoResolver;
+use Crtl\RequestDtoResolverBundle\Utility\DtoInstanceBagInterface;
+use Crtl\RequestDtoResolverBundle\Validator\RequestDtoValidator;
 use Symfony\Component\EventDispatcher\EventSubscriberInterface;
 use Symfony\Component\HttpKernel\Event\ControllerArgumentsEvent;
 use Symfony\Component\HttpKernel\KernelEvents;

--- a/src/EventSubscriber/RequestValidationExceptionEventSubscriber.php
+++ b/src/EventSubscriber/RequestValidationExceptionEventSubscriber.php
@@ -11,9 +11,9 @@
 
 declare(strict_types=1);
 
-namespace Crtl\RequestDTOResolverBundle\EventSubscriber;
+namespace Crtl\RequestDtoResolverBundle\EventSubscriber;
 
-use Crtl\RequestDTOResolverBundle\Exception\RequestValidationException;
+use Crtl\RequestDtoResolverBundle\Exception\RequestValidationException;
 use Symfony\Component\EventDispatcher\EventSubscriberInterface;
 use Symfony\Component\HttpFoundation\JsonResponse;
 use Symfony\Component\HttpFoundation\Response;
@@ -44,12 +44,12 @@ use Symfony\Component\HttpKernel\KernelEvents;
  * }
  * ```
  */
-class RequestValidationExceptionEventSubscriber implements EventSubscriberInterface
+final class RequestValidationExceptionEventSubscriber implements EventSubscriberInterface
 {
     public static function getSubscribedEvents(): array
     {
         return [
-            KernelEvents::EXCEPTION => ['onKernelException', -1024],
+            KernelEvents::EXCEPTION => ['onKernelException', -32],
         ];
     }
 
@@ -82,5 +82,6 @@ class RequestValidationExceptionEventSubscriber implements EventSubscriberInterf
 
         $response = new JsonResponse($data, Response::HTTP_BAD_REQUEST);
         $event->setResponse($response);
+        $event->stopPropagation();
     }
 }

--- a/src/Exception/RequestValidationException.php
+++ b/src/Exception/RequestValidationException.php
@@ -11,7 +11,7 @@
 
 declare(strict_types=1);
 
-namespace Crtl\RequestDTOResolverBundle\Exception;
+namespace Crtl\RequestDtoResolverBundle\Exception;
 
 use Symfony\Component\Validator\ConstraintViolationListInterface;
 

--- a/src/PropertyInfo/PropertyInfoExtractorFactory.php
+++ b/src/PropertyInfo/PropertyInfoExtractorFactory.php
@@ -1,0 +1,59 @@
+<?php
+
+/*
+ * This file is part of a private project.
+ *
+ * Copyright 2026 Crtl
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+declare(strict_types=1);
+
+namespace Crtl\RequestDtoResolverBundle\PropertyInfo;
+
+use Symfony\Component\PropertyInfo\Extractor\PhpDocExtractor;
+use Symfony\Component\PropertyInfo\Extractor\ReflectionExtractor;
+use Symfony\Component\PropertyInfo\PropertyInfoExtractor;
+
+class PropertyInfoExtractorFactory
+{
+    private PropertyInfoExtractor $extractor;
+
+    public function __construct(
+        private readonly PhpDocExtractor $phpDocExtractor,
+        private readonly ReflectionExtractor $reflectionExtractor,
+    ) {
+    }
+
+    public function create(): PropertyInfoExtractor
+    {
+        if (!isset($this->extractor)) {
+            // list of PropertyListExtractorInterface (any iterable)
+            $listExtractors = [$this->reflectionExtractor];
+
+            // list of PropertyTypeExtractorInterface (any iterable)
+            $typeExtractors = [$this->phpDocExtractor, $this->reflectionExtractor];
+
+            // list of PropertyDescriptionExtractorInterface (any iterable)
+            $descriptionExtractors = [$this->phpDocExtractor];
+
+            // list of PropertyAccessExtractorInterface (any iterable)
+            $accessExtractors = [$this->reflectionExtractor];
+
+            // list of PropertyInitializableExtractorInterface (any iterable)
+            $propertyInitializableExtractors = [$this->reflectionExtractor];
+
+            $this->extractor = new PropertyInfoExtractor(
+                $listExtractors,
+                $typeExtractors,
+                $descriptionExtractors,
+                $accessExtractors,
+                $propertyInitializableExtractors,
+            );
+        }
+
+        return $this->extractor;
+    }
+}

--- a/src/Reflection/RequestDtoMetadata.php
+++ b/src/Reflection/RequestDtoMetadata.php
@@ -11,9 +11,9 @@
 
 declare(strict_types=1);
 
-namespace Crtl\RequestDTOResolverBundle\Reflection;
+namespace Crtl\RequestDtoResolverBundle\Reflection;
 
-use Crtl\RequestDTOResolverBundle\Attribute\AbstractParam;
+use Crtl\RequestDtoResolverBundle\Attribute\AbstractParam;
 use Symfony\Component\Validator\Constraints\GroupSequence;
 use Symfony\Component\Validator\Mapping\ClassMetadataInterface;
 

--- a/src/Reflection/RequestDtoMetadataFactory.php
+++ b/src/Reflection/RequestDtoMetadataFactory.php
@@ -11,9 +11,9 @@
 
 declare(strict_types=1);
 
-namespace Crtl\RequestDTOResolverBundle\Reflection;
+namespace Crtl\RequestDtoResolverBundle\Reflection;
 
-use Crtl\RequestDTOResolverBundle\Utility\DtoReflectionHelper;
+use Crtl\RequestDtoResolverBundle\Utility\DtoReflectionHelper;
 use Psr\Cache\CacheItemPoolInterface;
 use Symfony\Component\Validator\Mapping\ClassMetadataInterface;
 use Symfony\Component\Validator\Validator\ValidatorInterface;

--- a/src/Reflection/RequestDtoParamMetadata.php
+++ b/src/Reflection/RequestDtoParamMetadata.php
@@ -11,9 +11,10 @@
 
 declare(strict_types=1);
 
-namespace Crtl\RequestDTOResolverBundle\Reflection;
+namespace Crtl\RequestDtoResolverBundle\Reflection;
 
-use Crtl\RequestDTOResolverBundle\Attribute\AbstractParam;
+use Crtl\RequestDtoResolverBundle\Attribute\AbstractParam;
+use Symfony\Component\TypeInfo\Type;
 
 class RequestDtoParamMetadata
 {
@@ -39,6 +40,26 @@ class RequestDtoParamMetadata
         private readonly string $propertyName,
 
         /**
+         * Name of the built-in type of the property.
+         * Name of the built-in type of the property.
+         *
+         * One of:
+         * - `"array"`
+         * - `"bool"`
+         * - `"callable"`
+         * - `"float"`
+         * - `"int"`
+         * - `"iterable"`
+         * - `"null"`
+         * - `"object"`
+         * - `"resource"`
+         * - `"string"`
+         *
+         * @var string
+         */
+        private readonly string $builtInType,
+
+        /**
          * Whether the property is constrained by validation.
          *
          * @var bool
@@ -51,12 +72,30 @@ class RequestDtoParamMetadata
          * @var class-string|null
          */
         private readonly ?string $nestedDtoClassName = null,
+
+        /**
+         * Whether the param is mapped to an array of DTOs.
+         *
+         * @var bool
+         */
+        private readonly bool $isNestedDtoArray = false,
+        private readonly bool $isNullable = false,
     ) {
+    }
+
+    public function getBuiltinType(): string
+    {
+        return $this->builtInType;
     }
 
     public function isConstrained(): bool
     {
         return $this->isConstrained;
+    }
+
+    public function isNestedDtoArray(): bool
+    {
+        return $this->isNestedDtoArray;
     }
 
     /**
@@ -78,6 +117,11 @@ class RequestDtoParamMetadata
     public function getPropertyName(): string
     {
         return $this->propertyName;
+    }
+
+    public function isNullable(): bool
+    {
+        return $this->isNullable;
     }
 
     /**
@@ -141,19 +185,33 @@ class RequestDtoParamMetadata
         return [
             'className' => $this->className,
             'propertyName' => $this->propertyName,
+            'builtInType' => $this->builtInType,
             'isConstrained' => $this->isConstrained,
             'nestedDtoClassName' => $this->nestedDtoClassName,
+            'isNestedDtoArray' => $this->isNestedDtoArray,
+            'isNullable' => $this->isNullable,
         ];
     }
 
     /**
-     * @param array{className: class-string, propertyName: string, isConstrained: bool, nestedDtoClassName: class-string|null} $data
+     * @param array{
+     *     className: class-string,
+     *     propertyName: string,
+     *     builtInType: string,
+     *     isConstrained: bool,
+     *     nestedDtoClassName: class-string|null,
+     *     isNestedDtoArray: bool,
+     *     isNullable: bool
+     * } $data
      */
     public function __unserialize(array $data): void
     {
         $this->className = $data['className'];
         $this->propertyName = $data['propertyName'];
+        $this->builtInType = $data['builtInType'];
         $this->isConstrained = $data['isConstrained'];
         $this->nestedDtoClassName = $data['nestedDtoClassName'];
+        $this->isNestedDtoArray = $data['isNestedDtoArray'];
+        $this->isNullable = $data['isNullable'];
     }
 }

--- a/src/Reflection/RequestDtoParamMetadataFactory.php
+++ b/src/Reflection/RequestDtoParamMetadataFactory.php
@@ -11,9 +11,14 @@
 
 declare(strict_types=1);
 
-namespace Crtl\RequestDTOResolverBundle\Reflection;
+namespace Crtl\RequestDtoResolverBundle\Reflection;
 
-use Crtl\RequestDTOResolverBundle\Utility\DtoReflectionHelper;
+use Crtl\RequestDtoResolverBundle\Utility\DtoReflectionHelper;
+use Crtl\RequestDtoResolverBundle\Utility\TypeHelper;
+use Symfony\Component\PropertyInfo\PropertyInfoExtractorInterface;
+use Symfony\Component\TypeInfo\Type\CollectionType;
+use Symfony\Component\TypeInfo\Type\ObjectType;
+use Symfony\Component\TypeInfo\Type\UnionType;
 use Symfony\Component\Validator\Mapping\ClassMetadataInterface;
 use Symfony\Component\Validator\Validator\ValidatorInterface;
 
@@ -22,6 +27,7 @@ class RequestDtoParamMetadataFactory
     public function __construct(
         private ValidatorInterface $validator,
         private DtoReflectionHelper $reflectionHelper,
+        private readonly PropertyInfoExtractorInterface $propertyInfoExtractor,
     ) {
     }
 
@@ -30,27 +36,54 @@ class RequestDtoParamMetadataFactory
         $className = $property->getDeclaringClass()->getName();
         $cacheKey = $className.'.'.$property->getName();
 
-        //        if ($cacheItem = $this->getCachedValue($cacheKey)) {
-        //            return $cacheItem;
-        //        }
-
         /** @var ClassMetadataInterface $validatorClassMetadata */
         $validatorClassMetadata = $this->validator->getMetadataFor($className);
         $constraintedProperties = $validatorClassMetadata->getConstrainedProperties();
 
         $propertyName = $property->getName();
 
-        /** @var class-string|null $nestedClassName */
-        $nestedClassName = $this->reflectionHelper->getDtoClassNameFromReflectionProperty($property)?->getName();
+        $type = $this->propertyInfoExtractor->getType($className, $propertyName);
+
+        $typeDescription = TypeHelper::describe($type);
+
+        $nestedClassName = null;
+        $isArrayType = false;
+
+        if ($type instanceof CollectionType) {
+            $isArrayType = true;
+            $type = $type->getCollectionValueType();
+        } elseif ($type instanceof UnionType) {
+            // get object type from union like ?T or null|T
+            foreach ($type->getTypes() as $unionType) {
+                if ($unionType instanceof ObjectType) {
+                    $type = $unionType;
+                    break;
+                }
+            }
+        }
+
+        if ($type instanceof ObjectType) {
+            $isDto = $this->reflectionHelper->isRequestDto($type->getClassName());
+
+            if ($isDto) {
+                $nestedClassName = $type->getClassName();
+            }
+        }
+
+        /** @var class-string|null $nestedClassName make phpstan happy */
+        $definetlyClassString = $nestedClassName;
 
         $metadata = new RequestDtoParamMetadata(
             $property->getDeclaringClass()->getName(),
             $propertyName,
+            $typeDescription['builtInType'],
             in_array($propertyName, $constraintedProperties, true),
-            $nestedClassName,
+            $definetlyClassString,
+            $isArrayType,
+            // check if type is nullable and fall back to true when no type specified
+            $property->getType()?->allowsNull() ?? true,
         );
 
-        //        $this->cacheValue($cacheKey, $metadata);
         return $metadata;
     }
 }

--- a/src/Reflection/WithCacheTrait.php
+++ b/src/Reflection/WithCacheTrait.php
@@ -11,7 +11,7 @@
 
 declare(strict_types=1);
 
-namespace Crtl\RequestDTOResolverBundle\Reflection;
+namespace Crtl\RequestDtoResolverBundle\Reflection;
 
 use Psr\Cache\CacheItemInterface;
 use Psr\Cache\CacheItemPoolInterface;

--- a/src/RequestDtoResolver.php
+++ b/src/RequestDtoResolver.php
@@ -11,11 +11,11 @@
 
 declare(strict_types=1);
 
-namespace Crtl\RequestDTOResolverBundle;
+namespace Crtl\RequestDtoResolverBundle;
 
-use Crtl\RequestDTOResolverBundle\Reflection\RequestDtoMetadataFactory;
-use Crtl\RequestDTOResolverBundle\Utility\DtoInstanceBagInterface;
-use Crtl\RequestDTOResolverBundle\Utility\DtoReflectionHelper;
+use Crtl\RequestDtoResolverBundle\Reflection\RequestDtoMetadataFactory;
+use Crtl\RequestDtoResolverBundle\Utility\DtoInstanceBagInterface;
+use Crtl\RequestDtoResolverBundle\Utility\DtoReflectionHelper;
 use Symfony\Component\HttpFoundation\Request;
 use Symfony\Component\HttpKernel\Controller\ValueResolverInterface;
 use Symfony\Component\HttpKernel\ControllerMetadata\ArgumentMetadata;

--- a/src/RequestDtoResolverBundle.php
+++ b/src/RequestDtoResolverBundle.php
@@ -11,7 +11,7 @@
 
 declare(strict_types=1);
 
-namespace Crtl\RequestDTOResolverBundle;
+namespace Crtl\RequestDtoResolverBundle;
 
 use Symfony\Component\DependencyInjection\ContainerBuilder;
 use Symfony\Component\DependencyInjection\Loader\Configurator\ContainerConfigurator;
@@ -28,5 +28,11 @@ class RequestDtoResolverBundle extends AbstractBundle
     public function loadExtension(array $config, ContainerConfigurator $container, ContainerBuilder $builder): void
     {
         $container->import('../config/services.php');
+        $env = $builder->getParameter('kernel.environment');
+
+        // Test overrides should come last
+        if ('test' === $env) {
+            $container->import('../config/services_test.php');
+        }
     }
 }

--- a/src/Trait/RequestDtoTrait.php
+++ b/src/Trait/RequestDtoTrait.php
@@ -1,0 +1,50 @@
+<?php
+
+/*
+ * This file is part of a private project.
+ *
+ * Copyright 2026 Crtl
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+declare(strict_types=1);
+
+namespace Crtl\RequestDtoResolverBundle\Trait;
+
+use Crtl\RequestDtoResolverBundle\Attribute\AbstractParam;
+use Symfony\Component\HttpFoundation\Request;
+
+trait RequestDtoTrait
+{
+    public function __construct(
+        private readonly Request $request
+    ) {
+    }
+
+    /**
+     * Helper to get values from request before hydration.
+     *
+     * !!!WARNING!!!: This does not for nested dtos.
+     *
+     * @throws \ReflectionException
+     */
+    public function getValue(string $property): mixed
+    {
+        $reflectionClass = new \ReflectionClass($this);
+        $reflectionProperty = $reflectionClass->getProperty($property);
+
+        $attrs = $reflectionProperty->getAttributes(AbstractParam::class, \ReflectionAttribute::IS_INSTANCEOF);
+
+        if (empty($attrs)) {
+            return $this->request->request->get($property);
+        }
+
+        /** @var AbstractParam $attr */
+        $attr = $attrs[0]->newInstance();
+        $attr->setProperty($reflectionProperty);
+
+        return $attr->getValueFromRequest($this->request);
+    }
+}

--- a/src/Utility/DtoInstanceBag.php
+++ b/src/Utility/DtoInstanceBag.php
@@ -11,7 +11,7 @@
 
 declare(strict_types=1);
 
-namespace Crtl\RequestDTOResolverBundle\Utility;
+namespace Crtl\RequestDtoResolverBundle\Utility;
 
 use Symfony\Component\HttpFoundation\Request;
 

--- a/src/Utility/DtoInstanceBagInterface.php
+++ b/src/Utility/DtoInstanceBagInterface.php
@@ -11,7 +11,7 @@
 
 declare(strict_types=1);
 
-namespace Crtl\RequestDTOResolverBundle\Utility;
+namespace Crtl\RequestDtoResolverBundle\Utility;
 
 use Symfony\Component\HttpFoundation\Request;
 

--- a/src/Utility/DtoReflectionHelper.php
+++ b/src/Utility/DtoReflectionHelper.php
@@ -11,10 +11,10 @@
 
 declare(strict_types=1);
 
-namespace Crtl\RequestDTOResolverBundle\Utility;
+namespace Crtl\RequestDtoResolverBundle\Utility;
 
-use Crtl\RequestDTOResolverBundle\Attribute\AbstractParam;
-use Crtl\RequestDTOResolverBundle\Attribute\RequestDto;
+use Crtl\RequestDtoResolverBundle\Attribute\AbstractParam;
+use Crtl\RequestDtoResolverBundle\Attribute\RequestDto;
 
 /**
  * @internal

--- a/src/Utility/TypeHelper.php
+++ b/src/Utility/TypeHelper.php
@@ -1,0 +1,96 @@
+<?php
+
+/*
+ * This file is part of a private project.
+ *
+ * Copyright 2026 Crtl
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+declare(strict_types=1);
+
+namespace Crtl\RequestDtoResolverBundle\Utility;
+
+use Symfony\Component\TypeInfo\Type;
+use Symfony\Component\TypeInfo\Type\CollectionType;
+use Symfony\Component\TypeInfo\Type\NullableType;
+use Symfony\Component\TypeInfo\Type\UnionType;
+
+final class TypeHelper
+{
+    /**
+     * @return array{builtInType: string, isNullable: bool, isCollection: bool, collectionValueType: ?Type}
+     */
+    public static function describe(?Type $type): array
+    {
+        if (null === $type) {
+            return [
+                'builtInType' => 'mixed',
+                'isNullable' => true,
+                'isCollection' => false,
+                'collectionValueType' => null,
+            ];
+        }
+
+        $isNullable = false;
+
+        // Unwrap "?T"
+        if ($type instanceof NullableType) {
+            $isNullable = true;
+            $type = $type->getWrappedType();
+        }
+
+        // Unwrap "T|null" (or bigger unions) by picking the first non-null type
+        if ($type instanceof UnionType) {
+            foreach ($type->getTypes() as $inner) {
+                if ($inner->isNullable()) {
+                    $isNullable = true;
+                    continue;
+                }
+
+                // Prefer non-null member
+                $type = $inner;
+                break;
+            }
+        }
+
+        // Collections: builtin is basically "array"/"iterable"
+        if ($type instanceof CollectionType) {
+            return [
+                'builtInType' => 'array',
+                'isNullable' => $isNullable,
+                'isCollection' => true,
+                'collectionValueType' => $type->getCollectionValueType(),
+            ];
+        }
+
+        if ($type instanceof Type\BuiltinType) {
+            return [
+                'builtInType' => $type->getTypeIdentifier()->name,
+                'isNullable' => $isNullable,
+                'isCollection' => false,
+                'collectionValueType' => null,
+            ];
+        }
+
+        if ($type instanceof Type\ObjectType) {
+            return [
+                'builtInType' => 'object',
+                'isNullable' => $isNullable,
+                'isCollection' => false,
+                'collectionValueType' => null,
+            ];
+        }
+
+        // Scalars / object / resource / callable, etc.
+        // TypeInfo exposes this as the "builtin type" concept.
+        return [
+            'builtInType' => method_exists($type, 'getBuiltinType') ? $type->getBuiltinType() : null,
+            'isNullable' => $isNullable,
+            'isCollection' => false,
+            'collectionValueType' => null,
+        ];
+    }
+}

--- a/src/Validator/GroupSequenceExtractor.php
+++ b/src/Validator/GroupSequenceExtractor.php
@@ -1,0 +1,76 @@
+<?php
+
+/*
+ * This file is part of a private project.
+ *
+ * Copyright 2026 Crtl
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+declare(strict_types=1);
+
+namespace Crtl\RequestDtoResolverBundle\Validator;
+
+use Psr\Container\ContainerInterface;
+use Symfony\Component\Validator\Constraint;
+use Symfony\Component\Validator\Constraints\GroupSequence;
+use Symfony\Component\Validator\GroupProviderInterface;
+use Symfony\Component\Validator\GroupSequenceProviderInterface;
+use Symfony\Component\Validator\Mapping\ClassMetadataInterface;
+
+class GroupSequenceExtractor
+{
+    public function __construct(
+        private readonly ?ContainerInterface $groupProviderLocator = null,
+    ) {
+    }
+
+    /**
+     * @param array<string[]|string|GroupSequence> $groups
+     *
+     * @return string[]|mixed[]|GroupSequence
+     *
+     * @throws \Psr\Container\ContainerExceptionInterface
+     * @throws \Psr\Container\NotFoundExceptionInterface
+     */
+    public function getGroupSequence(object $object, array $groups, ClassMetadataInterface $metadata): array|GroupSequence
+    {
+        $className = $metadata->getClassName();
+
+        // Return groups when not in default group
+        if (!in_array($className, $groups) || !in_array(Constraint::DEFAULT_GROUP, $groups)) {
+            return $groups;
+        }
+
+        if ($metadata->hasGroupSequence()) {
+            // The group sequence is statically defined for the class
+            return $metadata->getGroupSequence();
+        } elseif ($metadata->isGroupSequenceProvider()) {
+            // @phpstan-ignore function.alreadyNarrowedType
+            if (method_exists($metadata, 'getGroupProvider') && null !== $provider = $metadata->getGroupProvider()) {
+                if (null === $this->groupProviderLocator) {
+                    throw new \LogicException('A group provider locator is required when using group provider.');
+                }
+
+                /** @var GroupProviderInterface $provider */
+                $provider = $this->groupProviderLocator->get($provider);
+                $group = $provider->getGroups($object);
+            } else {
+                assert($object instanceof GroupSequenceProviderInterface);
+                // The group sequence is dynamically obtained from the validated
+                // object
+                $group = $object->getGroupSequence();
+            }
+
+            if (!$group instanceof GroupSequence) {
+                $group = new GroupSequence($group);
+            }
+
+            return $group;
+        }
+
+        return $groups;
+    }
+}

--- a/src/Validator/RequestDtoValidator.php
+++ b/src/Validator/RequestDtoValidator.php
@@ -11,13 +11,15 @@
 
 declare(strict_types=1);
 
-namespace Crtl\RequestDTOResolverBundle\Validator;
+namespace Crtl\RequestDtoResolverBundle\Validator;
 
-use Crtl\RequestDTOResolverBundle\Attribute\AbstractParam;
-use Crtl\RequestDTOResolverBundle\Reflection\RequestDtoMetadata;
-use Crtl\RequestDTOResolverBundle\Reflection\RequestDtoMetadataFactory;
+use Crtl\RequestDtoResolverBundle\Attribute\AbstractNestedParam;
+use Crtl\RequestDtoResolverBundle\Attribute\AbstractParam;
+use Crtl\RequestDtoResolverBundle\Reflection\RequestDtoMetadata;
+use Crtl\RequestDtoResolverBundle\Reflection\RequestDtoMetadataFactory;
 use Symfony\Component\HttpFoundation\Request;
 use Symfony\Component\Validator\Constraint;
+use Symfony\Component\Validator\Constraints\GroupSequence;
 use Symfony\Component\Validator\ConstraintViolation;
 use Symfony\Component\Validator\ConstraintViolationList;
 use Symfony\Component\Validator\ConstraintViolationListInterface;
@@ -31,14 +33,27 @@ use Symfony\Component\Validator\Validator\ValidatorInterface;
  */
 class RequestDtoValidator
 {
+    public const TYPE_DEFAULTS = [
+        'int' => 0,
+        'string' => '',
+        'float' => 0.0,
+        'bool' => false,
+        'array' => [],
+        'object' => null,
+        'null' => null,
+        'mixed' => null,
+        'iterable' => [],
+    ];
+
     public function __construct(
         private ValidatorInterface $validator,
         private RequestDtoMetadataFactory $metadataFactory,
+        private ?GroupSequenceExtractor $groupSequenceExtractor = null,
     ) {
     }
 
     /**
-     * @param array<string|string[]|\Symfony\Component\Validator\Constraints\GroupSequence>|null $groups
+     * @param array<string|string[]|GroupSequence>|null $groups
      */
     private function validateAndHydrateRecursive(
         object $dto,
@@ -50,17 +65,25 @@ class RequestDtoValidator
         $className = get_class($dto);
         $dtoMetadata ??= $this->metadataFactory->getMetadataFor($className);
 
+        if (empty($groups)) {
+            $groups = [Constraint::DEFAULT_GROUP, $className];
+        }
+
         $groupSequence = $dtoMetadata->getGroupSequence() ?? $groups;
 
-        if (empty($groupSequence)) {
-            $groupSequence = [[Constraint::DEFAULT_GROUP, $className]];
-        }
+        //        if (empty($groupSequence)) {
+        //            $groupSequence = [[Constraint::DEFAULT_GROUP, $className]];
+        //        }
 
         $violations = new ConstraintViolationList();
 
         /** @var list<callable> $values Callables which apply values to dto, stored for hydration after validation */
         $values = [];
         $hydrated = false;
+
+        $newGroupSequence = $this->groupSequenceExtractor->getGroupSequence($dto, $groups, $dtoMetadata->getValidatorMetadata());
+
+        $groupSequence = $newGroupSequence instanceof GroupSequence ? $newGroupSequence->groups : $newGroupSequence;
 
         foreach ($groupSequence as $groupToProcess) {
             $groupViolations = new ConstraintViolationList();
@@ -72,30 +95,57 @@ class RequestDtoValidator
                 $attr = $dtoMetadata->getAbstractParamAttributeFromProperty($reflectionProperty, $parent);
 
                 $dtoType = $propertyMetadata->getNestedDtoClassName();
-
                 // When the property is a nested RequestDTO we can recurse into custom validation and skip regular validator validation, because:
                 // class can either be valid or invalid, of a nested dto is not valid it therefore can also not be assigned to the property.
                 // therefore no other validation is required.
                 $value = $attr->getValueFromRequest($request);
                 if (null !== $dtoType) {
                     if (null !== $value) {
+                        $isArray = $propertyMetadata->isNestedDtoArray();
+
                         $nestedClassName = $dtoType;
                         /** @var class-string<object> $nestedClassName */
                         $nestedMetadata = $this->metadataFactory->getMetadataFor($nestedClassName);
-                        $value = $nestedMetadata->newInstance($request);
 
-                        $propertyViolations = $this->validateAndHydrateRecursive(
-                            $value,
-                            $request,
-                            is_array($groupToProcess) ? $groupToProcess : [$groupToProcess],
-                            $attr,
-                            $nestedMetadata,
-                        );
+                        $valueArray = $isArray ? $value : [$value];
+
+                        $propertyViolations = new ConstraintViolationList();
+                        $resultArray = [];
+                        foreach ($valueArray as $i => $nestedValue) {
+                            $instance = $nestedMetadata->newInstance($request);
+
+                            $nestedAttr = clone $attr;
+                            if ($isArray && $nestedAttr instanceof AbstractNestedParam) {
+                                $nestedAttr->setIndex($i);
+                            }
+
+                            $nestedViolations = $this->validateAndHydrateRecursive(
+                                $instance,
+                                $request,
+                                is_array($groupToProcess) ? $groupToProcess : [$groupToProcess],
+                                $nestedAttr,
+                                $nestedMetadata,
+                            );
+
+                            // Reset invalid object
+                            if ($nestedViolations->count() > 0) {
+                                $propertyViolations = $this->prefixViolations(
+                                    $propertyViolations,
+                                    // Append index to prefix only when in array mode
+                                    $isArray ? ($propertyName.".$i") : $propertyName,
+                                );
+                                $instance = null;
+                            }
+
+                            $resultArray[] = $instance;
+                            $propertyViolations->addAll($nestedViolations);
+                        }
 
                         // Reset invalid object
                         if ($propertyViolations->count() > 0) {
-                            $propertyViolations = $this->prefixViolations($propertyViolations, $reflectionProperty->getName());
                             $value = null;
+                        } else {
+                            $value = $isArray ? $resultArray : $resultArray[0];
                         }
                     } else {
                         $propertyViolations = new ConstraintViolationList();
@@ -149,8 +199,8 @@ class RequestDtoValidator
     }
 
     /**
-     * @param object                                                                             $dto
-     * @param array<string|string[]|\Symfony\Component\Validator\Constraints\GroupSequence>|null $groups
+     * @param object                                    $dto
+     * @param array<string|string[]|GroupSequence>|null $groups
      */
     public function validateAndHydrate($dto, Request $request, ?array $groups = null): ConstraintViolationListInterface
     {

--- a/test/Fixtures/AllParamTypesDTO.php
+++ b/test/Fixtures/AllParamTypesDTO.php
@@ -11,14 +11,14 @@
 
 declare(strict_types=1);
 
-namespace Crtl\RequestDTOResolverBundle\Test\Fixtures;
+namespace Crtl\RequestDtoResolverBundle\Test\Fixtures;
 
-use Crtl\RequestDTOResolverBundle\Attribute\BodyParam;
-use Crtl\RequestDTOResolverBundle\Attribute\FileParam;
-use Crtl\RequestDTOResolverBundle\Attribute\HeaderParam;
-use Crtl\RequestDTOResolverBundle\Attribute\QueryParam;
-use Crtl\RequestDTOResolverBundle\Attribute\RequestDto;
-use Crtl\RequestDTOResolverBundle\Attribute\RouteParam;
+use Crtl\RequestDtoResolverBundle\Attribute\BodyParam;
+use Crtl\RequestDtoResolverBundle\Attribute\FileParam;
+use Crtl\RequestDtoResolverBundle\Attribute\HeaderParam;
+use Crtl\RequestDtoResolverBundle\Attribute\QueryParam;
+use Crtl\RequestDtoResolverBundle\Attribute\RequestDto;
+use Crtl\RequestDtoResolverBundle\Attribute\RouteParam;
 use Symfony\Component\HttpFoundation\File\UploadedFile;
 
 #[RequestDto]

--- a/test/Fixtures/ArrayParamsDTO.php
+++ b/test/Fixtures/ArrayParamsDTO.php
@@ -11,11 +11,11 @@
 
 declare(strict_types=1);
 
-namespace Crtl\RequestDTOResolverBundle\Test\Fixtures;
+namespace Crtl\RequestDtoResolverBundle\Test\Fixtures;
 
-use Crtl\RequestDTOResolverBundle\Attribute\BodyParam;
-use Crtl\RequestDTOResolverBundle\Attribute\QueryParam;
-use Crtl\RequestDTOResolverBundle\Attribute\RequestDto;
+use Crtl\RequestDtoResolverBundle\Attribute\BodyParam;
+use Crtl\RequestDtoResolverBundle\Attribute\QueryParam;
+use Crtl\RequestDtoResolverBundle\Attribute\RequestDto;
 
 #[RequestDto]
 final class ArrayParamsDTO

--- a/test/Fixtures/BasicTypesDTO.php
+++ b/test/Fixtures/BasicTypesDTO.php
@@ -11,10 +11,10 @@
 
 declare(strict_types=1);
 
-namespace Crtl\RequestDTOResolverBundle\Test\Fixtures;
+namespace Crtl\RequestDtoResolverBundle\Test\Fixtures;
 
-use Crtl\RequestDTOResolverBundle\Attribute\BodyParam;
-use Crtl\RequestDTOResolverBundle\Attribute\RequestDto;
+use Crtl\RequestDtoResolverBundle\Attribute\BodyParam;
+use Crtl\RequestDtoResolverBundle\Attribute\RequestDto;
 
 #[RequestDto]
 final class BasicTypesDTO

--- a/test/Fixtures/Controller/TestController.php
+++ b/test/Fixtures/Controller/TestController.php
@@ -11,9 +11,9 @@
 
 declare(strict_types=1);
 
-namespace Crtl\RequestDTOResolverBundle\Test\Fixtures\Controller;
+namespace Crtl\RequestDtoResolverBundle\Test\Fixtures\Controller;
 
-use Crtl\RequestDTOResolverBundle\Test\Fixtures\StrictTypesDTO;
+use Crtl\RequestDtoResolverBundle\Test\Fixtures\StrictTypesDTO;
 use Symfony\Component\HttpFoundation\JsonResponse;
 
 final class TestController

--- a/test/Fixtures/DeeplyNestedDTO.php
+++ b/test/Fixtures/DeeplyNestedDTO.php
@@ -11,10 +11,10 @@
 
 declare(strict_types=1);
 
-namespace Crtl\RequestDTOResolverBundle\Test\Fixtures;
+namespace Crtl\RequestDtoResolverBundle\Test\Fixtures;
 
-use Crtl\RequestDTOResolverBundle\Attribute\BodyParam;
-use Crtl\RequestDTOResolverBundle\Attribute\RequestDto;
+use Crtl\RequestDtoResolverBundle\Attribute\BodyParam;
+use Crtl\RequestDtoResolverBundle\Attribute\RequestDto;
 
 #[RequestDto]
 final class DeeplyNestedDTO

--- a/test/Fixtures/DtoWithGroupSequenceProvider.php
+++ b/test/Fixtures/DtoWithGroupSequenceProvider.php
@@ -14,18 +14,20 @@ declare(strict_types=1);
 namespace Crtl\RequestDtoResolverBundle\Test\Fixtures;
 
 use Crtl\RequestDtoResolverBundle\Attribute\BodyParam;
-use Crtl\RequestDtoResolverBundle\Attribute\QueryParam;
 use Crtl\RequestDtoResolverBundle\Attribute\RequestDto;
+use Crtl\RequestDtoResolverBundle\Test\Fixtures\GroupProvider\TestGroupProvider;
+use Crtl\RequestDtoResolverBundle\Trait\RequestDtoTrait;
+use Symfony\Component\Validator\Constraints as Assert;
 
 #[RequestDto]
-final class NullableAndDefaultDTO
+#[Assert\GroupSequenceProvider(provider: TestGroupProvider::class)]
+class DtoWithGroupSequenceProvider
 {
+    use RequestDtoTrait;
     #[BodyParam]
-    public ?string $nullableString = null;
+    public ?string $first = null;
 
     #[BodyParam]
-    public string $withDefault = 'default value';
-
-    #[QueryParam]
-    public ?int $nullableInt = 10;
+    #[Assert\NotBlank(groups: ['First'])]
+    public ?string $second = null;
 }

--- a/test/Fixtures/DtoWithNestedDtoArray.php
+++ b/test/Fixtures/DtoWithNestedDtoArray.php
@@ -14,18 +14,14 @@ declare(strict_types=1);
 namespace Crtl\RequestDtoResolverBundle\Test\Fixtures;
 
 use Crtl\RequestDtoResolverBundle\Attribute\BodyParam;
-use Crtl\RequestDtoResolverBundle\Attribute\QueryParam;
 use Crtl\RequestDtoResolverBundle\Attribute\RequestDto;
 
 #[RequestDto]
-final class NullableAndDefaultDTO
+class DtoWithNestedDtoArray
 {
+    /**
+     * @var NestedChildDTO[]
+     */
     #[BodyParam]
-    public ?string $nullableString = null;
-
-    #[BodyParam]
-    public string $withDefault = 'default value';
-
-    #[QueryParam]
-    public ?int $nullableInt = 10;
+    public array $children;
 }

--- a/test/Fixtures/FileHandlingDTO.php
+++ b/test/Fixtures/FileHandlingDTO.php
@@ -11,10 +11,10 @@
 
 declare(strict_types=1);
 
-namespace Crtl\RequestDTOResolverBundle\Test\Fixtures;
+namespace Crtl\RequestDtoResolverBundle\Test\Fixtures;
 
-use Crtl\RequestDTOResolverBundle\Attribute\FileParam;
-use Crtl\RequestDTOResolverBundle\Attribute\RequestDto;
+use Crtl\RequestDtoResolverBundle\Attribute\FileParam;
+use Crtl\RequestDtoResolverBundle\Attribute\RequestDto;
 use Symfony\Component\HttpFoundation\File\UploadedFile;
 use Symfony\Component\Validator\Constraints as Assert;
 

--- a/test/Fixtures/GroupProvider/TestGroupProvider.php
+++ b/test/Fixtures/GroupProvider/TestGroupProvider.php
@@ -1,0 +1,34 @@
+<?php
+
+/*
+ * This file is part of a private project.
+ *
+ * Copyright 2026 Crtl
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+declare(strict_types=1);
+
+namespace Crtl\RequestDtoResolverBundle\Test\Fixtures\GroupProvider;
+
+use Crtl\RequestDtoResolverBundle\Test\Fixtures\DtoWithGroupSequenceProvider;
+use Symfony\Component\Validator\Constraints\GroupSequence;
+use Symfony\Component\Validator\GroupProviderInterface;
+
+class TestGroupProvider implements GroupProviderInterface
+{
+    public function getGroups(object $object): array|GroupSequence
+    {
+        assert($object instanceof DtoWithGroupSequenceProvider);
+
+        $groups = [self::class];
+
+        if ('validate_second' === $object->getValue('first')) {
+            $groups[] = 'First';
+        }
+
+        return $groups;
+    }
+}

--- a/test/Fixtures/GroupSequenceProviderDTO.php
+++ b/test/Fixtures/GroupSequenceProviderDTO.php
@@ -1,0 +1,45 @@
+<?php
+
+/*
+ * This file is part of a private project.
+ *
+ * Copyright 2026 Crtl
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+declare(strict_types=1);
+
+namespace Crtl\RequestDtoResolverBundle\Test\Fixtures;
+
+use Crtl\RequestDtoResolverBundle\Attribute\BodyParam;
+use Crtl\RequestDtoResolverBundle\Attribute\RequestDto;
+use Crtl\RequestDtoResolverBundle\Trait\RequestDtoTrait;
+use Symfony\Component\Validator\Constraints as Assert;
+use Symfony\Component\Validator\GroupSequenceProviderInterface;
+
+#[RequestDto]
+#[Assert\GroupSequenceProvider]
+final class GroupSequenceProviderDTO implements GroupSequenceProviderInterface
+{
+    use RequestDtoTrait;
+
+    #[BodyParam]
+    public ?string $first = null;
+
+    #[BodyParam]
+    #[Assert\NotBlank(groups: ['First'])]
+    public ?string $second = null;
+
+    public function getGroupSequence(): array
+    {
+        $groups = [self::class];
+
+        if ('validate_second' === $this->getValue('first')) {
+            $groups[] = 'First';
+        }
+
+        return $groups;
+    }
+}

--- a/test/Fixtures/Legacy/AllParamTypesDTO.php
+++ b/test/Fixtures/Legacy/AllParamTypesDTO.php
@@ -11,14 +11,14 @@
 
 declare(strict_types=1);
 
-namespace Crtl\RequestDTOResolverBundle\Test\Fixtures\Legacy;
+namespace Crtl\RequestDtoResolverBundle\Test\Fixtures\Legacy;
 
-use Crtl\RequestDTOResolverBundle\Attribute\BodyParam;
-use Crtl\RequestDTOResolverBundle\Attribute\FileParam;
-use Crtl\RequestDTOResolverBundle\Attribute\HeaderParam;
-use Crtl\RequestDTOResolverBundle\Attribute\QueryParam;
-use Crtl\RequestDTOResolverBundle\Attribute\RequestDto;
-use Crtl\RequestDTOResolverBundle\Attribute\RouteParam;
+use Crtl\RequestDtoResolverBundle\Attribute\BodyParam;
+use Crtl\RequestDtoResolverBundle\Attribute\FileParam;
+use Crtl\RequestDtoResolverBundle\Attribute\HeaderParam;
+use Crtl\RequestDtoResolverBundle\Attribute\QueryParam;
+use Crtl\RequestDtoResolverBundle\Attribute\RequestDto;
+use Crtl\RequestDtoResolverBundle\Attribute\RouteParam;
 
 #[RequestDto]
 final class AllParamTypesDTO

--- a/test/Fixtures/Legacy/ArrayParamsDTO.php
+++ b/test/Fixtures/Legacy/ArrayParamsDTO.php
@@ -11,11 +11,11 @@
 
 declare(strict_types=1);
 
-namespace Crtl\RequestDTOResolverBundle\Test\Fixtures\Legacy;
+namespace Crtl\RequestDtoResolverBundle\Test\Fixtures\Legacy;
 
-use Crtl\RequestDTOResolverBundle\Attribute\BodyParam;
-use Crtl\RequestDTOResolverBundle\Attribute\QueryParam;
-use Crtl\RequestDTOResolverBundle\Attribute\RequestDto;
+use Crtl\RequestDtoResolverBundle\Attribute\BodyParam;
+use Crtl\RequestDtoResolverBundle\Attribute\QueryParam;
+use Crtl\RequestDtoResolverBundle\Attribute\RequestDto;
 
 #[RequestDto]
 final class ArrayParamsDTO

--- a/test/Fixtures/Legacy/BasicTypesDTO.php
+++ b/test/Fixtures/Legacy/BasicTypesDTO.php
@@ -11,10 +11,10 @@
 
 declare(strict_types=1);
 
-namespace Crtl\RequestDTOResolverBundle\Test\Fixtures\Legacy;
+namespace Crtl\RequestDtoResolverBundle\Test\Fixtures\Legacy;
 
-use Crtl\RequestDTOResolverBundle\Attribute\BodyParam;
-use Crtl\RequestDTOResolverBundle\Attribute\RequestDto;
+use Crtl\RequestDtoResolverBundle\Attribute\BodyParam;
+use Crtl\RequestDtoResolverBundle\Attribute\RequestDto;
 
 #[RequestDto]
 final class BasicTypesDTO

--- a/test/Fixtures/Legacy/DeeplyNestedDTO.php
+++ b/test/Fixtures/Legacy/DeeplyNestedDTO.php
@@ -11,10 +11,10 @@
 
 declare(strict_types=1);
 
-namespace Crtl\RequestDTOResolverBundle\Test\Fixtures\Legacy;
+namespace Crtl\RequestDtoResolverBundle\Test\Fixtures\Legacy;
 
-use Crtl\RequestDTOResolverBundle\Attribute\BodyParam;
-use Crtl\RequestDTOResolverBundle\Attribute\RequestDto;
+use Crtl\RequestDtoResolverBundle\Attribute\BodyParam;
+use Crtl\RequestDtoResolverBundle\Attribute\RequestDto;
 
 #[RequestDto]
 final class DeeplyNestedDTO

--- a/test/Fixtures/Legacy/ExampleDto.php
+++ b/test/Fixtures/Legacy/ExampleDto.php
@@ -11,14 +11,14 @@
 
 declare(strict_types=1);
 
-namespace Crtl\RequestDTOResolverBundle\Test\Fixtures\Legacy;
+namespace Crtl\RequestDtoResolverBundle\Test\Fixtures\Legacy;
 
-use Crtl\RequestDTOResolverBundle\Attribute\BodyParam;
-use Crtl\RequestDTOResolverBundle\Attribute\FileParam;
-use Crtl\RequestDTOResolverBundle\Attribute\HeaderParam;
-use Crtl\RequestDTOResolverBundle\Attribute\QueryParam;
-use Crtl\RequestDTOResolverBundle\Attribute\RequestDto;
-use Crtl\RequestDTOResolverBundle\Attribute\RouteParam;
+use Crtl\RequestDtoResolverBundle\Attribute\BodyParam;
+use Crtl\RequestDtoResolverBundle\Attribute\FileParam;
+use Crtl\RequestDtoResolverBundle\Attribute\HeaderParam;
+use Crtl\RequestDtoResolverBundle\Attribute\QueryParam;
+use Crtl\RequestDtoResolverBundle\Attribute\RequestDto;
+use Crtl\RequestDtoResolverBundle\Attribute\RouteParam;
 use Symfony\Component\HttpFoundation\Request;
 use Symfony\Component\Validator\Constraints as Assert;
 

--- a/test/Fixtures/Legacy/FileHandlingDTO.php
+++ b/test/Fixtures/Legacy/FileHandlingDTO.php
@@ -11,10 +11,10 @@
 
 declare(strict_types=1);
 
-namespace Crtl\RequestDTOResolverBundle\Test\Fixtures\Legacy;
+namespace Crtl\RequestDtoResolverBundle\Test\Fixtures\Legacy;
 
-use Crtl\RequestDTOResolverBundle\Attribute\FileParam;
-use Crtl\RequestDTOResolverBundle\Attribute\RequestDto;
+use Crtl\RequestDtoResolverBundle\Attribute\FileParam;
+use Crtl\RequestDtoResolverBundle\Attribute\RequestDto;
 use Symfony\Component\Validator\Constraints as Assert;
 
 #[RequestDto]

--- a/test/Fixtures/Legacy/NestedChildDTO.php
+++ b/test/Fixtures/Legacy/NestedChildDTO.php
@@ -11,10 +11,10 @@
 
 declare(strict_types=1);
 
-namespace Crtl\RequestDTOResolverBundle\Test\Fixtures\Legacy;
+namespace Crtl\RequestDtoResolverBundle\Test\Fixtures\Legacy;
 
-use Crtl\RequestDTOResolverBundle\Attribute\BodyParam;
-use Crtl\RequestDTOResolverBundle\Attribute\RequestDto;
+use Crtl\RequestDtoResolverBundle\Attribute\BodyParam;
+use Crtl\RequestDtoResolverBundle\Attribute\RequestDto;
 use Symfony\Component\Validator\Constraints as Assert;
 
 #[RequestDto]

--- a/test/Fixtures/Legacy/NestedParentDTO.php
+++ b/test/Fixtures/Legacy/NestedParentDTO.php
@@ -11,10 +11,10 @@
 
 declare(strict_types=1);
 
-namespace Crtl\RequestDTOResolverBundle\Test\Fixtures\Legacy;
+namespace Crtl\RequestDtoResolverBundle\Test\Fixtures\Legacy;
 
-use Crtl\RequestDTOResolverBundle\Attribute\BodyParam;
-use Crtl\RequestDTOResolverBundle\Attribute\RequestDto;
+use Crtl\RequestDtoResolverBundle\Attribute\BodyParam;
+use Crtl\RequestDtoResolverBundle\Attribute\RequestDto;
 use Symfony\Component\Validator\Constraints as Assert;
 
 #[RequestDto]

--- a/test/Fixtures/Legacy/NullableAndDefaultDTO.php
+++ b/test/Fixtures/Legacy/NullableAndDefaultDTO.php
@@ -11,11 +11,11 @@
 
 declare(strict_types=1);
 
-namespace Crtl\RequestDTOResolverBundle\Test\Fixtures\Legacy;
+namespace Crtl\RequestDtoResolverBundle\Test\Fixtures\Legacy;
 
-use Crtl\RequestDTOResolverBundle\Attribute\BodyParam;
-use Crtl\RequestDTOResolverBundle\Attribute\QueryParam;
-use Crtl\RequestDTOResolverBundle\Attribute\RequestDto;
+use Crtl\RequestDtoResolverBundle\Attribute\BodyParam;
+use Crtl\RequestDtoResolverBundle\Attribute\QueryParam;
+use Crtl\RequestDtoResolverBundle\Attribute\RequestDto;
 
 #[RequestDto]
 final class NullableAndDefaultDTO

--- a/test/Fixtures/Legacy/ParameterMappingDTO.php
+++ b/test/Fixtures/Legacy/ParameterMappingDTO.php
@@ -11,13 +11,13 @@
 
 declare(strict_types=1);
 
-namespace Crtl\RequestDTOResolverBundle\Test\Fixtures\Legacy;
+namespace Crtl\RequestDtoResolverBundle\Test\Fixtures\Legacy;
 
-use Crtl\RequestDTOResolverBundle\Attribute\BodyParam;
-use Crtl\RequestDTOResolverBundle\Attribute\HeaderParam;
-use Crtl\RequestDTOResolverBundle\Attribute\QueryParam;
-use Crtl\RequestDTOResolverBundle\Attribute\RequestDto;
-use Crtl\RequestDTOResolverBundle\Attribute\RouteParam;
+use Crtl\RequestDtoResolverBundle\Attribute\BodyParam;
+use Crtl\RequestDtoResolverBundle\Attribute\HeaderParam;
+use Crtl\RequestDtoResolverBundle\Attribute\QueryParam;
+use Crtl\RequestDtoResolverBundle\Attribute\RequestDto;
+use Crtl\RequestDtoResolverBundle\Attribute\RouteParam;
 
 #[RequestDto]
 final class ParameterMappingDTO

--- a/test/Fixtures/Legacy/UnionTypesDTO.php
+++ b/test/Fixtures/Legacy/UnionTypesDTO.php
@@ -11,11 +11,11 @@
 
 declare(strict_types=1);
 
-namespace Crtl\RequestDTOResolverBundle\Test\Fixtures\Legacy;
+namespace Crtl\RequestDtoResolverBundle\Test\Fixtures\Legacy;
 
-use Crtl\RequestDTOResolverBundle\Attribute\BodyParam;
-use Crtl\RequestDTOResolverBundle\Attribute\QueryParam;
-use Crtl\RequestDTOResolverBundle\Attribute\RequestDto;
+use Crtl\RequestDtoResolverBundle\Attribute\BodyParam;
+use Crtl\RequestDtoResolverBundle\Attribute\QueryParam;
+use Crtl\RequestDtoResolverBundle\Attribute\RequestDto;
 
 #[RequestDto]
 final class UnionTypesDTO

--- a/test/Fixtures/NestedChildDTO.php
+++ b/test/Fixtures/NestedChildDTO.php
@@ -11,10 +11,10 @@
 
 declare(strict_types=1);
 
-namespace Crtl\RequestDTOResolverBundle\Test\Fixtures;
+namespace Crtl\RequestDtoResolverBundle\Test\Fixtures;
 
-use Crtl\RequestDTOResolverBundle\Attribute\BodyParam;
-use Crtl\RequestDTOResolverBundle\Attribute\RequestDto;
+use Crtl\RequestDtoResolverBundle\Attribute\BodyParam;
+use Crtl\RequestDtoResolverBundle\Attribute\RequestDto;
 use Symfony\Component\Validator\Constraints as Assert;
 
 #[RequestDto]

--- a/test/Fixtures/NestedParentDTO.php
+++ b/test/Fixtures/NestedParentDTO.php
@@ -11,10 +11,10 @@
 
 declare(strict_types=1);
 
-namespace Crtl\RequestDTOResolverBundle\Test\Fixtures;
+namespace Crtl\RequestDtoResolverBundle\Test\Fixtures;
 
-use Crtl\RequestDTOResolverBundle\Attribute\BodyParam;
-use Crtl\RequestDTOResolverBundle\Attribute\RequestDto;
+use Crtl\RequestDtoResolverBundle\Attribute\BodyParam;
+use Crtl\RequestDtoResolverBundle\Attribute\RequestDto;
 use Symfony\Component\Validator\Constraints as Assert;
 
 #[RequestDto]

--- a/test/Fixtures/ParameterMappingDTO.php
+++ b/test/Fixtures/ParameterMappingDTO.php
@@ -11,13 +11,13 @@
 
 declare(strict_types=1);
 
-namespace Crtl\RequestDTOResolverBundle\Test\Fixtures;
+namespace Crtl\RequestDtoResolverBundle\Test\Fixtures;
 
-use Crtl\RequestDTOResolverBundle\Attribute\BodyParam;
-use Crtl\RequestDTOResolverBundle\Attribute\HeaderParam;
-use Crtl\RequestDTOResolverBundle\Attribute\QueryParam;
-use Crtl\RequestDTOResolverBundle\Attribute\RequestDto;
-use Crtl\RequestDTOResolverBundle\Attribute\RouteParam;
+use Crtl\RequestDtoResolverBundle\Attribute\BodyParam;
+use Crtl\RequestDtoResolverBundle\Attribute\HeaderParam;
+use Crtl\RequestDtoResolverBundle\Attribute\QueryParam;
+use Crtl\RequestDtoResolverBundle\Attribute\RequestDto;
+use Crtl\RequestDtoResolverBundle\Attribute\RouteParam;
 
 #[RequestDto]
 final class ParameterMappingDTO

--- a/test/Fixtures/ReadonlyPropertyDTO.php
+++ b/test/Fixtures/ReadonlyPropertyDTO.php
@@ -11,10 +11,10 @@
 
 declare(strict_types=1);
 
-namespace Crtl\RequestDTOResolverBundle\Test\Fixtures;
+namespace Crtl\RequestDtoResolverBundle\Test\Fixtures;
 
-use Crtl\RequestDTOResolverBundle\Attribute\BodyParam;
-use Crtl\RequestDTOResolverBundle\Attribute\RequestDto;
+use Crtl\RequestDtoResolverBundle\Attribute\BodyParam;
+use Crtl\RequestDtoResolverBundle\Attribute\RequestDto;
 use Symfony\Component\HttpFoundation\Request;
 
 #[RequestDto]

--- a/test/Fixtures/RequestConstructorDTO.php
+++ b/test/Fixtures/RequestConstructorDTO.php
@@ -11,10 +11,10 @@
 
 declare(strict_types=1);
 
-namespace Crtl\RequestDTOResolverBundle\Test\Fixtures;
+namespace Crtl\RequestDtoResolverBundle\Test\Fixtures;
 
-use Crtl\RequestDTOResolverBundle\Attribute\BodyParam;
-use Crtl\RequestDTOResolverBundle\Attribute\RequestDto;
+use Crtl\RequestDtoResolverBundle\Attribute\BodyParam;
+use Crtl\RequestDtoResolverBundle\Attribute\RequestDto;
 use Symfony\Component\HttpFoundation\Request;
 
 #[RequestDto]

--- a/test/Fixtures/StaticPropertyDTO.php
+++ b/test/Fixtures/StaticPropertyDTO.php
@@ -11,10 +11,10 @@
 
 declare(strict_types=1);
 
-namespace Crtl\RequestDTOResolverBundle\Test\Fixtures;
+namespace Crtl\RequestDtoResolverBundle\Test\Fixtures;
 
-use Crtl\RequestDTOResolverBundle\Attribute\BodyParam;
-use Crtl\RequestDTOResolverBundle\Attribute\RequestDto;
+use Crtl\RequestDtoResolverBundle\Attribute\BodyParam;
+use Crtl\RequestDtoResolverBundle\Attribute\RequestDto;
 
 #[RequestDto]
 final class StaticPropertyDTO

--- a/test/Fixtures/StrictTypesDTO.php
+++ b/test/Fixtures/StrictTypesDTO.php
@@ -11,10 +11,10 @@
 
 declare(strict_types=1);
 
-namespace Crtl\RequestDTOResolverBundle\Test\Fixtures;
+namespace Crtl\RequestDtoResolverBundle\Test\Fixtures;
 
-use Crtl\RequestDTOResolverBundle\Attribute\BodyParam;
-use Crtl\RequestDTOResolverBundle\Attribute\RequestDto;
+use Crtl\RequestDtoResolverBundle\Attribute\BodyParam;
+use Crtl\RequestDtoResolverBundle\Attribute\RequestDto;
 use Symfony\Component\Validator\Constraints as Assert;
 
 #[RequestDto]

--- a/test/Fixtures/UnionTypesDTO.php
+++ b/test/Fixtures/UnionTypesDTO.php
@@ -11,11 +11,11 @@
 
 declare(strict_types=1);
 
-namespace Crtl\RequestDTOResolverBundle\Test\Fixtures;
+namespace Crtl\RequestDtoResolverBundle\Test\Fixtures;
 
-use Crtl\RequestDTOResolverBundle\Attribute\BodyParam;
-use Crtl\RequestDTOResolverBundle\Attribute\QueryParam;
-use Crtl\RequestDTOResolverBundle\Attribute\RequestDto;
+use Crtl\RequestDtoResolverBundle\Attribute\BodyParam;
+use Crtl\RequestDtoResolverBundle\Attribute\QueryParam;
+use Crtl\RequestDtoResolverBundle\Attribute\RequestDto;
 
 #[RequestDto]
 final class UnionTypesDTO

--- a/test/Integration/DtoReflectionHelperIntegrationTest.php
+++ b/test/Integration/DtoReflectionHelperIntegrationTest.php
@@ -11,13 +11,13 @@
 
 declare(strict_types=1);
 
-namespace Crtl\RequestDTOResolverBundle\Test\Integration;
+namespace Crtl\RequestDtoResolverBundle\Test\Integration;
 
-use Crtl\RequestDTOResolverBundle\Attribute\BodyParam;
-use Crtl\RequestDTOResolverBundle\Attribute\RequestDto;
-use Crtl\RequestDTOResolverBundle\Test\Fixtures\AllParamTypesDTO;
-use Crtl\RequestDTOResolverBundle\Test\Fixtures\NestedChildDTO;
-use Crtl\RequestDTOResolverBundle\Utility\DtoReflectionHelper;
+use Crtl\RequestDtoResolverBundle\Attribute\BodyParam;
+use Crtl\RequestDtoResolverBundle\Attribute\RequestDto;
+use Crtl\RequestDtoResolverBundle\Test\Fixtures\AllParamTypesDTO;
+use Crtl\RequestDtoResolverBundle\Test\Fixtures\NestedChildDTO;
+use Crtl\RequestDtoResolverBundle\Utility\DtoReflectionHelper;
 use PHPUnit\Framework\TestCase;
 
 final class DtoReflectionHelperIntegrationTest extends TestCase

--- a/test/Integration/RequestDtoResolverBundleIntegrationTest.php
+++ b/test/Integration/RequestDtoResolverBundleIntegrationTest.php
@@ -11,14 +11,18 @@
 
 declare(strict_types=1);
 
-namespace Crtl\RequestDTOResolverBundle\Test\Integration;
+namespace Crtl\RequestDtoResolverBundle\Test\Integration;
 
-use Crtl\RequestDTOResolverBundle\Test\Fixtures\Legacy\ExampleDto;
-use Crtl\RequestDTOResolverBundle\Test\Fixtures\StrictTypesDTO;
+use Crtl\RequestDtoResolverBundle\Test\Fixtures\DtoWithGroupSequenceProvider;
+use Crtl\RequestDtoResolverBundle\Test\Fixtures\DtoWithNestedDtoArray;
+use Crtl\RequestDtoResolverBundle\Test\Fixtures\GroupSequenceProviderDTO;
+use Crtl\RequestDtoResolverBundle\Test\Fixtures\Legacy\ExampleDto;
+use Crtl\RequestDtoResolverBundle\Test\Fixtures\StrictTypesDTO;
 use Symfony\Bundle\FrameworkBundle\Test\KernelTestCase;
 use Symfony\Component\HttpFoundation\File\UploadedFile;
 use Symfony\Component\HttpFoundation\JsonResponse;
 use Symfony\Component\HttpFoundation\Request;
+use Symfony\Component\HttpFoundation\Response;
 
 final class RequestDtoResolverBundleIntegrationTest extends KernelTestCase
 {
@@ -90,15 +94,15 @@ final class RequestDtoResolverBundleIntegrationTest extends KernelTestCase
         self::assertNull($data['nullableArray']);
     }
 
-    public function testThrowsWhenValidationFails(): void
+    public function testReturns400WhenValidationFails(): void
     {
         self::bootKernel();
         $kernel = self::$kernel;
 
         $payload = [
             'string' => '',      // NotBlank violation
-            'int' => 0,          // NotBlank considers 0 as blank -> violation (Symfony behavior)
-            'float' => 0.0,      // NotBlank considers 0.0 as blank -> violation
+            'int' => null,          // NotBlank considers 0 as blank -> violation (Symfony behavior)
+            'float' => null,      // NotBlank considers 0.0 as blank -> violation
             'bool' => false,     // NotBlank considers false as blank -> violation
             'array' => [],       // NotBlank considers empty array as blank -> violation
         ];
@@ -123,11 +127,11 @@ final class RequestDtoResolverBundleIntegrationTest extends KernelTestCase
         $request->attributes->set('_controller', $controller);
 
         // Replace with your concrete exception type:
-        // e.g. \Crtl\RequestDTOResolverBundle\Exception\RequestDtoValidationException::class
+        // e.g. \Crtl\RequestDtoResolverBundle\Exception\RequestDtoValidationException::class
 
         $response = $kernel->handle($request);
 
-        self::assertSame(500, $response->getStatusCode());
+        $this->assertValidationErrorResponse($response, ['string', 'int', 'float', 'bool', 'array']);
     }
 
     public function testControllerIsCalledWithLegacyDto(): void
@@ -189,13 +193,13 @@ final class RequestDtoResolverBundleIntegrationTest extends KernelTestCase
         self::assertSame('queryValue', $data['query']);
         self::assertSame(123, $data['id']);
         self::assertSame('nestedValue', $data['nestedBodyDto']);
-        self::assertSame('nestedValue', $data['nestedQueryParamDto']);
+        self::assertSame('nestedQueryValue', $data['nestedQueryParamDto']);
         self::assertTrue($data['requestInjected']);
 
         @unlink($tempFile);
     }
 
-    public function testThrowsWhenWithLegacyDtoAndInvalidData(): void
+    public function testReturns400WithLegacyDtoAndInvalidData(): void
     {
         self::bootKernel();
         $kernel = self::$kernel;
@@ -224,6 +228,179 @@ final class RequestDtoResolverBundleIntegrationTest extends KernelTestCase
 
         $response = $kernel->handle($request);
 
-        self::assertSame(500, $response->getStatusCode());
+        self::assertSame(400, $response->getStatusCode());
+    }
+
+    public function testDtoWithNestedDtoArray(): void
+    {
+        self::bootKernel();
+        $kernel = self::$kernel;
+
+        $payload = [
+            'children' => [
+                ['childName' => 'child1'],
+                ['childName' => 'child2'],
+                ['childName' => 'child3'],
+            ]
+        ];
+
+        $request = Request::create(
+            uri: '/_test',
+            method: 'POST',
+            server: [
+                'CONTENT_TYPE' => 'application/json',
+                'HTTP_ACCEPT' => 'application/json',
+            ],
+            content: json_encode($payload, JSON_THROW_ON_ERROR),
+        );
+
+        $controller = new class {
+            public function __invoke(DtoWithNestedDtoArray $dto): JsonResponse
+            {
+                $children = [];
+                foreach ($dto->children as $child) {
+                    $children[] = ['childName' => $child->childName];
+                }
+
+                return new JsonResponse([
+                    'children' => $children
+                ]);
+            }
+        };
+
+        $request->attributes->set('_controller', $controller);
+
+        $response = $kernel->handle($request);
+        $json = json_decode((string) $response->getContent(), true, 512, JSON_THROW_ON_ERROR);
+
+        self::assertSame(200, $response->getStatusCode());
+        self::assertSame($payload, $json);
+    }
+
+    /**
+     * @param array<string, string|null> $payload
+     *
+     * @dataProvider provideGroupSequenceTestData
+     */
+    public function testRequestDtoWithGroupSequenceProviderInterfaceHydratesAndValidatesCorrectly(array $payload, int $expectedStatus): void
+    {
+        self::bootKernel();
+        $kernel = self::$kernel;
+
+        $request = Request::create(
+            uri: '/_test_group_sequence',
+            method: 'POST',
+            server: [
+                'CONTENT_TYPE' => 'application/json',
+                'HTTP_ACCEPT' => 'application/json',
+            ],
+            content: json_encode($payload, JSON_THROW_ON_ERROR),
+        );
+
+        $controller = new class {
+            public function __invoke(GroupSequenceProviderDTO $dto): JsonResponse
+            {
+                return new JsonResponse(get_object_vars($dto));
+            }
+        };
+
+        $request->attributes->set('_controller', $controller);
+
+        $response = $kernel->handle($request);
+
+        self::assertSame($expectedStatus, $response->getStatusCode());
+
+        if (200 === $expectedStatus) {
+            $data = json_decode((string) $response->getContent(), true, 512, JSON_THROW_ON_ERROR);
+            foreach ($payload as $key => $value) {
+                self::assertSame($value, $data[$key]);
+            }
+        } elseif (400 === $expectedStatus) {
+            $this->assertValidationErrorResponse($response);
+        }
+    }
+
+    /**
+     * @param array<string, string|null> $payload
+     *
+     * @dataProvider provideGroupSequenceTestData
+     */
+    public function testRequestDtoWithGroupSequenceProviderServiceHydratesAndValidatesCorrectly(array $payload, int $expectedStatus): void
+    {
+        self::bootKernel();
+        $kernel = self::$kernel;
+
+        $request = Request::create(
+            uri: '/_test_group_sequence',
+            method: 'POST',
+            server: [
+                'CONTENT_TYPE' => 'application/json',
+                'HTTP_ACCEPT' => 'application/json',
+            ],
+            content: json_encode($payload, JSON_THROW_ON_ERROR),
+        );
+
+        $controller = new class {
+            public function __invoke(DtoWithGroupSequenceProvider $dto): JsonResponse
+            {
+                return new JsonResponse(get_object_vars($dto));
+            }
+        };
+
+        $request->attributes->set('_controller', $controller);
+
+        $response = $kernel->handle($request);
+
+        self::assertSame($expectedStatus, $response->getStatusCode());
+
+        if (200 === $expectedStatus) {
+            $data = json_decode((string) $response->getContent(), true, 512, JSON_THROW_ON_ERROR);
+            foreach ($payload as $key => $value) {
+                self::assertSame($value, $data[$key]);
+            }
+        } elseif (400 === $expectedStatus) {
+            $this->assertValidationErrorResponse($response);
+        }
+    }
+
+    /**
+     * @return iterable<string, array{array<string, string|null>, int}>
+     */
+    public static function provideGroupSequenceTestData(): iterable
+    {
+        yield 'valid without triggering second group' => [
+            ['first' => 'foo', 'second' => null],
+            200
+        ];
+
+        yield 'valid triggering second group' => [
+            ['first' => 'validate_second', 'second' => 'bar'],
+            200
+        ];
+
+        yield 'invalid triggering second group' => [
+            ['first' => 'validate_second', 'second' => null],
+            400
+        ];
+    }
+
+    /**
+     * @param string[] $fields
+     *
+     * @throws \JsonException
+     */
+    private function assertValidationErrorResponse(Response $response, array $fields = []): void
+    {
+        $content = $response->getContent();
+        self::assertEquals(400, $response->getStatusCode());
+        self::assertNotFalse($content);
+
+        $json = json_decode($content, true, 512, JSON_THROW_ON_ERROR);
+        self::assertArrayHasKey('message', $json);
+        self::assertArrayHasKey('errors', $json);
+
+        foreach ($fields as $field) {
+            self::assertArrayHasKey($field, $json['errors'], "Expected error for field $field not found");
+        }
     }
 }

--- a/test/Integration/RequestDtoValidatorIntegrationTest.php
+++ b/test/Integration/RequestDtoValidatorIntegrationTest.php
@@ -11,17 +11,21 @@
 
 declare(strict_types=1);
 
-namespace Crtl\RequestDTOResolverBundle\Test\Integration;
+namespace Crtl\RequestDtoResolverBundle\Test\Integration;
 
-use Crtl\RequestDTOResolverBundle\Attribute\BodyParam;
-use Crtl\RequestDTOResolverBundle\Attribute\QueryParam;
-use Crtl\RequestDTOResolverBundle\Attribute\RequestDto;
-use Crtl\RequestDTOResolverBundle\Reflection\RequestDtoMetadataFactory;
-use Crtl\RequestDTOResolverBundle\Reflection\RequestDtoParamMetadataFactory;
-use Crtl\RequestDTOResolverBundle\Utility\DtoReflectionHelper;
-use Crtl\RequestDTOResolverBundle\Validator\RequestDtoValidator;
+use Crtl\RequestDtoResolverBundle\Attribute\BodyParam;
+use Crtl\RequestDtoResolverBundle\Attribute\QueryParam;
+use Crtl\RequestDtoResolverBundle\Attribute\RequestDto;
+use Crtl\RequestDtoResolverBundle\PropertyInfo\PropertyInfoExtractorFactory;
+use Crtl\RequestDtoResolverBundle\Reflection\RequestDtoMetadataFactory;
+use Crtl\RequestDtoResolverBundle\Reflection\RequestDtoParamMetadataFactory;
+use Crtl\RequestDtoResolverBundle\Utility\DtoReflectionHelper;
+use Crtl\RequestDtoResolverBundle\Validator\GroupSequenceExtractor;
+use Crtl\RequestDtoResolverBundle\Validator\RequestDtoValidator;
 use PHPUnit\Framework\TestCase;
 use Symfony\Component\HttpFoundation\Request;
+use Symfony\Component\PropertyInfo\Extractor\PhpDocExtractor;
+use Symfony\Component\PropertyInfo\Extractor\ReflectionExtractor;
 use Symfony\Component\Validator\Constraints as Assert;
 use Symfony\Component\Validator\ConstraintViolationListInterface;
 use Symfony\Component\Validator\Validation;
@@ -135,10 +139,18 @@ final class RequestDtoValidatorIntegrationTest extends TestCase
             ->enableAttributeMapping()
             ->getValidator();
 
+        $extractorFactory = new PropertyInfoExtractorFactory(
+            new PhpDocExtractor(),
+            new ReflectionExtractor(),
+        );
+
+        $propertyInfoExtractor = $extractorFactory->create();
+
         $reflectionHelper = new DtoReflectionHelper();
-        $paramMetadataFactory = new RequestDtoParamMetadataFactory($innerValidator, $reflectionHelper);
+        $paramMetadataFactory = new RequestDtoParamMetadataFactory($innerValidator, $reflectionHelper, $propertyInfoExtractor);
         $metadataFactory = new RequestDtoMetadataFactory($innerValidator, $reflectionHelper, $paramMetadataFactory);
-        $this->validator = new RequestDtoValidator($innerValidator, $metadataFactory);
+        $groupSequenceExtractor = new GroupSequenceExtractor();
+        $this->validator = new RequestDtoValidator($innerValidator, $metadataFactory, $groupSequenceExtractor);
     }
 
     // @phpstan-ignore method.unused

--- a/test/TestKernel.php
+++ b/test/TestKernel.php
@@ -11,9 +11,9 @@
 
 declare(strict_types=1);
 
-namespace Crtl\RequestDTOResolverBundle\Test;
+namespace Crtl\RequestDtoResolverBundle\Test;
 
-use Crtl\RequestDTOResolverBundle\RequestDtoResolverBundle;
+use Crtl\RequestDtoResolverBundle\RequestDtoResolverBundle;
 use Symfony\Bundle\FrameworkBundle\FrameworkBundle;
 use Symfony\Component\Config\Loader\LoaderInterface;
 use Symfony\Component\HttpKernel\Kernel;

--- a/test/Unit/Attribute/AbstractParamTest.php
+++ b/test/Unit/Attribute/AbstractParamTest.php
@@ -11,9 +11,9 @@
 
 declare(strict_types=1);
 
-namespace Crtl\RequestDTOResolverBundle\Test\Unit\Attribute;
+namespace Crtl\RequestDtoResolverBundle\Test\Unit\Attribute;
 
-use Crtl\RequestDTOResolverBundle\Attribute\AbstractParam;
+use Crtl\RequestDtoResolverBundle\Attribute\AbstractParam;
 use PHPUnit\Framework\TestCase;
 use Symfony\Component\HttpFoundation\Request;
 

--- a/test/Unit/Attribute/BodyParamTest.php
+++ b/test/Unit/Attribute/BodyParamTest.php
@@ -11,9 +11,9 @@
 
 declare(strict_types=1);
 
-namespace Crtl\RequestDTOResolverBundle\Test\Unit\Attribute;
+namespace Crtl\RequestDtoResolverBundle\Test\Unit\Attribute;
 
-use Crtl\RequestDTOResolverBundle\Attribute\BodyParam;
+use Crtl\RequestDtoResolverBundle\Attribute\BodyParam;
 use PHPUnit\Framework\TestCase;
 use Symfony\Component\HttpFoundation\Request;
 
@@ -37,5 +37,22 @@ final class BodyParamTest extends TestCase
         $bodyParam = new BodyParam('missing_param');
 
         $this->assertNull($bodyParam->getValueFromRequest($request));
+    }
+
+    public function testGetNestedArrayValue(): void
+    {
+        $bodyParam = new BodyParam('name');
+        $parent = new BodyParam('children');
+        $parent->setIndex(0);
+        $bodyParam->setParent($parent);
+
+        $request = new Request(request: [
+            'children' => [
+                ['name' => 'John Doe']
+            ]
+        ]);
+
+        $value = $bodyParam->getValueFromRequest($request);
+        self::assertSame('John Doe', $value);
     }
 }

--- a/test/Unit/Attribute/FileParamTest.php
+++ b/test/Unit/Attribute/FileParamTest.php
@@ -11,9 +11,9 @@
 
 declare(strict_types=1);
 
-namespace Crtl\RequestDTOResolverBundle\Test\Unit\Attribute;
+namespace Crtl\RequestDtoResolverBundle\Test\Unit\Attribute;
 
-use Crtl\RequestDTOResolverBundle\Attribute\FileParam;
+use Crtl\RequestDtoResolverBundle\Attribute\FileParam;
 use PHPUnit\Framework\MockObject\Exception;
 use PHPUnit\Framework\TestCase;
 use Symfony\Component\HttpFoundation\File\UploadedFile;

--- a/test/Unit/Attribute/HeaderParamTest.php
+++ b/test/Unit/Attribute/HeaderParamTest.php
@@ -11,9 +11,9 @@
 
 declare(strict_types=1);
 
-namespace Crtl\RequestDTOResolverBundle\Test\Unit\Attribute;
+namespace Crtl\RequestDtoResolverBundle\Test\Unit\Attribute;
 
-use Crtl\RequestDTOResolverBundle\Attribute\HeaderParam;
+use Crtl\RequestDtoResolverBundle\Attribute\HeaderParam;
 use PHPUnit\Framework\TestCase;
 use Symfony\Component\HttpFoundation\Request;
 

--- a/test/Unit/Attribute/QueryParamTest.php
+++ b/test/Unit/Attribute/QueryParamTest.php
@@ -11,9 +11,9 @@
 
 declare(strict_types=1);
 
-namespace Crtl\RequestDTOResolverBundle\Test\Unit\Attribute;
+namespace Crtl\RequestDtoResolverBundle\Test\Unit\Attribute;
 
-use Crtl\RequestDTOResolverBundle\Attribute\QueryParam;
+use Crtl\RequestDtoResolverBundle\Attribute\QueryParam;
 use PHPUnit\Framework\Attributes\DataProvider;
 use PHPUnit\Framework\TestCase;
 use Symfony\Component\HttpFoundation\Request;

--- a/test/Unit/Attribute/RouteParamTest.php
+++ b/test/Unit/Attribute/RouteParamTest.php
@@ -11,9 +11,9 @@
 
 declare(strict_types=1);
 
-namespace Crtl\RequestDTOResolverBundle\Test\Unit\Attribute;
+namespace Crtl\RequestDtoResolverBundle\Test\Unit\Attribute;
 
-use Crtl\RequestDTOResolverBundle\Attribute\RouteParam;
+use Crtl\RequestDtoResolverBundle\Attribute\RouteParam;
 use PHPUnit\Framework\TestCase;
 use Symfony\Component\HttpFoundation\Request;
 

--- a/test/Unit/DtoInstanceBagTest.php
+++ b/test/Unit/DtoInstanceBagTest.php
@@ -11,9 +11,9 @@
 
 declare(strict_types=1);
 
-namespace Crtl\RequestDTOResolverBundle\Test\Unit;
+namespace Crtl\RequestDtoResolverBundle\Test\Unit;
 
-use Crtl\RequestDTOResolverBundle\Utility\DtoInstanceBag;
+use Crtl\RequestDtoResolverBundle\Utility\DtoInstanceBag;
 use PHPUnit\Framework\TestCase;
 use Symfony\Component\HttpFoundation\Request;
 

--- a/test/Unit/EventSubscriber/RequestDtoValidationEventSubscriberTest.php
+++ b/test/Unit/EventSubscriber/RequestDtoValidationEventSubscriberTest.php
@@ -11,12 +11,12 @@
 
 declare(strict_types=1);
 
-namespace Crtl\RequestDTOResolverBundle\Test\Unit\EventSubscriber;
+namespace Crtl\RequestDtoResolverBundle\Test\Unit\EventSubscriber;
 
-use Crtl\RequestDTOResolverBundle\EventSubscriber\RequestDtoValidationEventSubscriber;
-use Crtl\RequestDTOResolverBundle\Exception\RequestValidationException;
-use Crtl\RequestDTOResolverBundle\Utility\DtoInstanceBagInterface;
-use Crtl\RequestDTOResolverBundle\Validator\RequestDtoValidator;
+use Crtl\RequestDtoResolverBundle\EventSubscriber\RequestDtoValidationEventSubscriber;
+use Crtl\RequestDtoResolverBundle\Exception\RequestValidationException;
+use Crtl\RequestDtoResolverBundle\Utility\DtoInstanceBagInterface;
+use Crtl\RequestDtoResolverBundle\Validator\RequestDtoValidator;
 use PHPUnit\Framework\MockObject\MockObject;
 use PHPUnit\Framework\TestCase;
 use Symfony\Component\HttpFoundation\Request;

--- a/test/Unit/EventSubscriber/RequestValidationExceptionEventSubscriberTest.php
+++ b/test/Unit/EventSubscriber/RequestValidationExceptionEventSubscriberTest.php
@@ -11,10 +11,10 @@
 
 declare(strict_types=1);
 
-namespace Crtl\RequestDTOResolverBundle\Test\Unit\EventSubscriber;
+namespace Crtl\RequestDtoResolverBundle\Test\Unit\EventSubscriber;
 
-use Crtl\RequestDTOResolverBundle\EventSubscriber\RequestValidationExceptionEventSubscriber;
-use Crtl\RequestDTOResolverBundle\Exception\RequestValidationException;
+use Crtl\RequestDtoResolverBundle\EventSubscriber\RequestValidationExceptionEventSubscriber;
+use Crtl\RequestDtoResolverBundle\Exception\RequestValidationException;
 use PHPUnit\Framework\TestCase;
 use Symfony\Component\HttpFoundation\JsonResponse;
 use Symfony\Component\HttpFoundation\Request;
@@ -38,7 +38,7 @@ final class RequestValidationExceptionEventSubscriberTest extends TestCase
     {
         $subscribedEvents = RequestValidationExceptionEventSubscriber::getSubscribedEvents();
         self::assertArrayHasKey(KernelEvents::EXCEPTION, $subscribedEvents);
-        self::assertEquals(['onKernelException', -1024], $subscribedEvents[KernelEvents::EXCEPTION]);
+        self::assertEquals(['onKernelException', -32], $subscribedEvents[KernelEvents::EXCEPTION]);
     }
 
     public function testOnKernelExceptionSkipsSubRequests(): void

--- a/test/Unit/Exception/RequestValidationExceptionTest.php
+++ b/test/Unit/Exception/RequestValidationExceptionTest.php
@@ -11,9 +11,9 @@
 
 declare(strict_types=1);
 
-namespace Crtl\RequestDTOResolverBundle\Test\Unit\Exception;
+namespace Crtl\RequestDtoResolverBundle\Test\Unit\Exception;
 
-use Crtl\RequestDTOResolverBundle\Exception\RequestValidationException;
+use Crtl\RequestDtoResolverBundle\Exception\RequestValidationException;
 use PHPUnit\Framework\MockObject\Exception;
 use PHPUnit\Framework\MockObject\MockObject;
 use PHPUnit\Framework\TestCase;

--- a/test/Unit/Reflection/RequestDtoMetadataFactoryTest.php
+++ b/test/Unit/Reflection/RequestDtoMetadataFactoryTest.php
@@ -11,13 +11,13 @@
 
 declare(strict_types=1);
 
-namespace Crtl\RequestDTOResolverBundle\Test\Unit\Reflection;
+namespace Crtl\RequestDtoResolverBundle\Test\Unit\Reflection;
 
-use Crtl\RequestDTOResolverBundle\Reflection\RequestDtoMetadata;
-use Crtl\RequestDTOResolverBundle\Reflection\RequestDtoMetadataFactory;
-use Crtl\RequestDTOResolverBundle\Reflection\RequestDtoParamMetadata;
-use Crtl\RequestDTOResolverBundle\Reflection\RequestDtoParamMetadataFactory;
-use Crtl\RequestDTOResolverBundle\Utility\DtoReflectionHelper;
+use Crtl\RequestDtoResolverBundle\Reflection\RequestDtoMetadata;
+use Crtl\RequestDtoResolverBundle\Reflection\RequestDtoMetadataFactory;
+use Crtl\RequestDtoResolverBundle\Reflection\RequestDtoParamMetadata;
+use Crtl\RequestDtoResolverBundle\Reflection\RequestDtoParamMetadataFactory;
+use Crtl\RequestDtoResolverBundle\Utility\DtoReflectionHelper;
 use PHPUnit\Framework\MockObject\MockObject;
 use PHPUnit\Framework\TestCase;
 use Psr\Cache\CacheItemInterface;
@@ -63,7 +63,7 @@ final class RequestDtoMetadataFactoryTest extends TestCase
         $this->paramMetadataFactory->expects($this->exactly(2))
             ->method('getMetadataFor')
             ->willReturnCallback(function (\ReflectionProperty $prop) {
-                return new RequestDtoParamMetadata($prop->getDeclaringClass()->getName(), $prop->getName(), 'prop1' === $prop->getName());
+                return new RequestDtoParamMetadata($prop->getDeclaringClass()->getName(), $prop->getName(), 'mixed', 'prop1' === $prop->getName());
             });
 
         $metadata = $this->factory->getMetadataFor($className);

--- a/test/Unit/Reflection/RequestDtoMetadataTest.php
+++ b/test/Unit/Reflection/RequestDtoMetadataTest.php
@@ -11,12 +11,12 @@
 
 declare(strict_types=1);
 
-namespace Crtl\RequestDTOResolverBundle\Test\Unit\Reflection;
+namespace Crtl\RequestDtoResolverBundle\Test\Unit\Reflection;
 
-use Crtl\RequestDTOResolverBundle\Attribute\FileParam;
-use Crtl\RequestDTOResolverBundle\Attribute\QueryParam;
-use Crtl\RequestDTOResolverBundle\Reflection\RequestDtoMetadata;
-use Crtl\RequestDTOResolverBundle\Reflection\RequestDtoParamMetadata;
+use Crtl\RequestDtoResolverBundle\Attribute\FileParam;
+use Crtl\RequestDtoResolverBundle\Attribute\QueryParam;
+use Crtl\RequestDtoResolverBundle\Reflection\RequestDtoMetadata;
+use Crtl\RequestDtoResolverBundle\Reflection\RequestDtoParamMetadata;
 use PHPUnit\Framework\TestCase;
 use Symfony\Component\Validator\Constraints\GroupSequence;
 use Symfony\Component\Validator\Mapping\ClassMetadata;
@@ -31,8 +31,8 @@ final class RequestDtoMetadataTest extends TestCase
         $metadata = new RequestDtoMetadata(
             DummyRequestDto::class,
             [
-                new RequestDtoParamMetadata(DummyRequestDto::class, 'prop1', false),
-                new RequestDtoParamMetadata(DummyRequestDto::class, 'prop2', false),
+                new RequestDtoParamMetadata(DummyRequestDto::class, 'prop1', 'string', false),
+                new RequestDtoParamMetadata(DummyRequestDto::class, 'prop2', 'string', false),
             ],
             $validatorMetadata,
         );
@@ -47,8 +47,8 @@ final class RequestDtoMetadataTest extends TestCase
         $metadata = new RequestDtoMetadata(
             DummyRequestDto::class,
             [
-                new RequestDtoParamMetadata(DummyRequestDto::class, 'prop1', true),
-                new RequestDtoParamMetadata(DummyRequestDto::class, 'prop2', false),
+                new RequestDtoParamMetadata(DummyRequestDto::class, 'prop1', 'mixed', true),
+                new RequestDtoParamMetadata(DummyRequestDto::class, 'prop2', 'mixed', false),
             ],
             $this->createMock(ClassMetadataInterface::class),
         );
@@ -120,8 +120,8 @@ final class RequestDtoMetadataTest extends TestCase
         $metadata = new RequestDtoMetadata(
             DummyRequestDto::class,
             [
-                new RequestDtoParamMetadata(DummyRequestDto::class, 'prop1', true),
-                new RequestDtoParamMetadata(DummyRequestDto::class, 'prop2', false),
+                new RequestDtoParamMetadata(DummyRequestDto::class, 'prop1', 'mixed', true),
+                new RequestDtoParamMetadata(DummyRequestDto::class, 'prop2', 'mixed', false),
             ],
             $validatorMetadata,
         );
@@ -144,8 +144,8 @@ final class RequestDtoMetadataTest extends TestCase
         $metadata = new RequestDtoMetadata(
             DummyRequestDto::class,
             [
-                new RequestDtoParamMetadata(DummyRequestDto::class, 'prop1', true),
-                new RequestDtoParamMetadata(DummyRequestDto::class, 'prop2', false),
+                new RequestDtoParamMetadata(DummyRequestDto::class, 'prop1', 'mixed', true),
+                new RequestDtoParamMetadata(DummyRequestDto::class, 'prop2', 'mixed', false),
             ],
             $this->createMock(ClassMetadataInterface::class),
         );
@@ -153,7 +153,7 @@ final class RequestDtoMetadataTest extends TestCase
         $property = $metadata->getPropertyMetadata('prop1')->getReflectionProperty();
 
         $this->expectException(\LogicException::class);
-        $this->expectExceptionMessage('Property Crtl\RequestDTOResolverBundle\Test\Unit\Reflection\DummyRequestDto::$prop1 is missing an AbstractParam attribute.');
+        $this->expectExceptionMessage('Property Crtl\RequestDtoResolverBundle\Test\Unit\Reflection\DummyRequestDto::$prop1 is missing an AbstractParam attribute.');
 
         $metadata->getAbstractParamAttributeFromProperty($property);
     }
@@ -163,7 +163,7 @@ final class RequestDtoMetadataTest extends TestCase
         $metadata = new RequestDtoMetadata(
             DtoWithMultipleAttributes::class,
             [
-                new RequestDtoParamMetadata(DtoWithMultipleAttributes::class, 'prop', false),
+                new RequestDtoParamMetadata(DtoWithMultipleAttributes::class, 'prop', 'string', false),
             ],
             $this->createMock(ClassMetadataInterface::class),
         );
@@ -172,7 +172,7 @@ final class RequestDtoMetadataTest extends TestCase
 
         set_error_handler(function ($errno, $errstr) {
             $this->assertEquals(E_USER_WARNING, $errno);
-            $this->assertStringContainsString('Property Crtl\RequestDTOResolverBundle\Test\Unit\Reflection\DtoWithMultipleAttributes::$prop has more than one AbstractParam attribute', $errstr);
+            $this->assertStringContainsString('Property Crtl\RequestDtoResolverBundle\Test\Unit\Reflection\DtoWithMultipleAttributes::$prop has more than one AbstractParam attribute', $errstr);
 
             return true;
         }, E_USER_WARNING);

--- a/test/Unit/Reflection/RequestDtoParamMetadataTest.php
+++ b/test/Unit/Reflection/RequestDtoParamMetadataTest.php
@@ -11,56 +11,56 @@
 
 declare(strict_types=1);
 
-namespace Crtl\RequestDTOResolverBundle\Test\Unit\Reflection;
+namespace Crtl\RequestDtoResolverBundle\Test\Unit\Reflection;
 
-use Crtl\RequestDTOResolverBundle\Attribute\AbstractParam;
-use Crtl\RequestDTOResolverBundle\Attribute\BodyParam;
-use Crtl\RequestDTOResolverBundle\Attribute\QueryParam;
-use Crtl\RequestDTOResolverBundle\Reflection\RequestDtoParamMetadata;
+use Crtl\RequestDtoResolverBundle\Attribute\AbstractParam;
+use Crtl\RequestDtoResolverBundle\Attribute\BodyParam;
+use Crtl\RequestDtoResolverBundle\Attribute\QueryParam;
+use Crtl\RequestDtoResolverBundle\Reflection\RequestDtoParamMetadata;
 use PHPUnit\Framework\TestCase;
 
 final class RequestDtoParamMetadataTest extends TestCase
 {
     public function testGetClassNameReturnsCorrectClassName(): void
     {
-        $metadata = new RequestDtoParamMetadata(ParamMetadataDummyDto::class, 'prop', true);
+        $metadata = new RequestDtoParamMetadata(ParamMetadataDummyDto::class, 'prop', 'mixed', false);
         $this->assertEquals(ParamMetadataDummyDto::class, $metadata->getClassName());
     }
 
     public function testGetPropertyNameReturnsCorrectPropertyName(): void
     {
-        $metadata = new RequestDtoParamMetadata(ParamMetadataDummyDto::class, 'prop', true);
+        $metadata = new RequestDtoParamMetadata(ParamMetadataDummyDto::class, 'prop', 'mixed', false);
         $this->assertEquals('prop', $metadata->getPropertyName());
     }
 
     public function testIsConstrainedReturnsCorrectValue(): void
     {
-        $metadataTrue = new RequestDtoParamMetadata(ParamMetadataDummyDto::class, 'prop', true);
+        $metadataTrue = new RequestDtoParamMetadata(ParamMetadataDummyDto::class, 'prop', 'string', true);
         $this->assertTrue($metadataTrue->isConstrained());
 
-        $metadataFalse = new RequestDtoParamMetadata(ParamMetadataDummyDto::class, 'prop', false);
+        $metadataFalse = new RequestDtoParamMetadata(ParamMetadataDummyDto::class, 'prop', 'string', false);
         $this->assertFalse($metadataFalse->isConstrained());
     }
 
     public function testGetNestedDtoClassNameReturnsCorrectClassName(): void
     {
-        $metadata = new RequestDtoParamMetadata(ParamMetadataDummyDto::class, 'prop', true, ParamMetadataNestedDto::class);
+        $metadata = new RequestDtoParamMetadata(ParamMetadataDummyDto::class, 'prop', 'mixed', true, ParamMetadataNestedDto::class);
         $this->assertEquals(ParamMetadataNestedDto::class, $metadata->getNestedDtoClassName());
 
-        $metadataNull = new RequestDtoParamMetadata(ParamMetadataDummyDto::class, 'prop', true, null);
+        $metadataNull = new RequestDtoParamMetadata(ParamMetadataDummyDto::class, 'prop', 'mixed', true, null);
         $this->assertNull($metadataNull->getNestedDtoClassName());
     }
 
     public function testGetReflectionClassReturnsCorrectReflectionClass(): void
     {
-        $metadata = new RequestDtoParamMetadata(ParamMetadataDummyDto::class, 'prop', true);
+        $metadata = new RequestDtoParamMetadata(ParamMetadataDummyDto::class, 'prop', 'mixed', false);
         $reflection = $metadata->getReflectionClass();
         $this->assertEquals(ParamMetadataDummyDto::class, $reflection->getName());
     }
 
     public function testGetReflectionPropertyReturnsCorrectReflectionProperty(): void
     {
-        $metadata = new RequestDtoParamMetadata(ParamMetadataDummyDto::class, 'prop', true);
+        $metadata = new RequestDtoParamMetadata(ParamMetadataDummyDto::class, 'prop', 'mixed', true);
         $reflection = $metadata->getReflectionProperty();
         $this->assertEquals('prop', $reflection->getName());
         $this->assertEquals(ParamMetadataDummyDto::class, $reflection->getDeclaringClass()->getName());
@@ -68,7 +68,7 @@ final class RequestDtoParamMetadataTest extends TestCase
 
     public function testGetAttributeReturnsAbstractParamAttribute(): void
     {
-        $metadata = new RequestDtoParamMetadata(ParamMetadataDummyDto::class, 'prop', true);
+        $metadata = new RequestDtoParamMetadata(ParamMetadataDummyDto::class, 'prop', 'mixed', true);
         $attribute = $metadata->getAttribute();
         $this->assertInstanceOf(QueryParam::class, $attribute);
         $this->assertEquals('prop', $attribute->getName());
@@ -76,7 +76,7 @@ final class RequestDtoParamMetadataTest extends TestCase
 
     public function testGetAttributeSetsParentAttributeWhenProvided(): void
     {
-        $metadata = new RequestDtoParamMetadata(ParamMetadataDummyDto::class, 'prop', true);
+        $metadata = new RequestDtoParamMetadata(ParamMetadataDummyDto::class, 'prop', 'mixed', true);
         $parent = new BodyParam();
         $attribute = $metadata->getAttribute($parent);
 
@@ -87,15 +87,15 @@ final class RequestDtoParamMetadataTest extends TestCase
 
     public function testGetAttributeThrowsLogicExceptionWhenAttributeIsMissing(): void
     {
-        $metadata = new RequestDtoParamMetadata(ParamMetadataDummyDto::class, 'noAttributeProp', true);
+        $metadata = new RequestDtoParamMetadata(ParamMetadataDummyDto::class, 'noAttributeProp', 'mixed', true);
         $this->expectException(\LogicException::class);
-        $this->expectExceptionMessage('Property Crtl\RequestDTOResolverBundle\Test\Unit\Reflection\ParamMetadataDummyDto::$noAttributeProp is missing an AbstractParam attribute.');
+        $this->expectExceptionMessage('Property Crtl\RequestDtoResolverBundle\Test\Unit\Reflection\ParamMetadataDummyDto::$noAttributeProp is missing an AbstractParam attribute.');
         $metadata->getAttribute();
     }
 
     public function testGetAttributeTriggersWarningWhenMultipleAttributesArePresent(): void
     {
-        $metadata = new RequestDtoParamMetadata(ParamMetadataDummyDto::class, 'multipleAttributesProp', true);
+        $metadata = new RequestDtoParamMetadata(ParamMetadataDummyDto::class, 'multipleAttributesProp', 'mixed', true);
 
         $warningTriggered = false;
         set_error_handler(function ($errno, $errstr) use (&$warningTriggered) {
@@ -117,10 +117,44 @@ final class RequestDtoParamMetadataTest extends TestCase
 
     public function testSetValueSetsPropertyValueOnDto(): void
     {
-        $metadata = new RequestDtoParamMetadata(ParamMetadataDummyDto::class, 'prop', true);
+        $metadata = new RequestDtoParamMetadata(ParamMetadataDummyDto::class, 'prop', 'mixed', true);
         $dto = new ParamMetadataDummyDto();
         $metadata->setValue($dto, 'new value');
         $this->assertEquals('new value', $dto->prop);
+    }
+
+    public function testIsNullable(): void
+    {
+        $metadata = new RequestDtoParamMetadata(ParamMetadataDummyDto::class, 'prop', 'mixed', true);
+        self::assertFalse($metadata->isNullable());
+
+        $metadata = new RequestDtoParamMetadata(ParamMetadataDummyDto::class, 'prop', 'mixed', true, isNullable: true);
+        self::assertTrue($metadata->isNullable());
+    }
+
+    public function testSerializeAndUnserializeWorksCorrectly(): void
+    {
+        $metadata = new RequestDtoParamMetadata(
+            ParamMetadataDummyDto::class,
+            'prop',
+            'string',
+            true,
+            ParamMetadataNestedDto::class,
+            true,
+            true,
+        );
+
+        $serialized = serialize($metadata);
+        /** @var RequestDtoParamMetadata $unserialized */
+        $unserialized = unserialize($serialized);
+
+        $this->assertEquals($metadata->getClassName(), $unserialized->getClassName());
+        $this->assertEquals($metadata->getPropertyName(), $unserialized->getPropertyName());
+        $this->assertEquals($metadata->getBuiltinType(), $unserialized->getBuiltinType());
+        $this->assertEquals($metadata->isConstrained(), $unserialized->isConstrained());
+        $this->assertEquals($metadata->getNestedDtoClassName(), $unserialized->getNestedDtoClassName());
+        $this->assertEquals($metadata->isNestedDtoArray(), $unserialized->isNestedDtoArray());
+        $this->assertEquals($metadata->isNullable(), $unserialized->isNullable());
     }
 }
 

--- a/test/Unit/RequestDtoResolverTest.php
+++ b/test/Unit/RequestDtoResolverTest.php
@@ -29,14 +29,14 @@ declare(strict_types=1);
 
 /** @noinspection PhpUnhandledExceptionInspection */
 
-namespace Crtl\RequestDTOResolverBundle\Test\Unit;
+namespace Crtl\RequestDtoResolverBundle\Test\Unit;
 
-use Crtl\RequestDTOResolverBundle\Attribute;
-use Crtl\RequestDTOResolverBundle\Reflection\RequestDtoMetadata;
-use Crtl\RequestDTOResolverBundle\Reflection\RequestDtoMetadataFactory;
-use Crtl\RequestDTOResolverBundle\RequestDtoResolver;
-use Crtl\RequestDTOResolverBundle\Utility\DtoInstanceBagInterface;
-use Crtl\RequestDTOResolverBundle\Utility\DtoReflectionHelper;
+use Crtl\RequestDtoResolverBundle\Attribute;
+use Crtl\RequestDtoResolverBundle\Reflection\RequestDtoMetadata;
+use Crtl\RequestDtoResolverBundle\Reflection\RequestDtoMetadataFactory;
+use Crtl\RequestDtoResolverBundle\RequestDtoResolver;
+use Crtl\RequestDtoResolverBundle\Utility\DtoInstanceBagInterface;
+use Crtl\RequestDtoResolverBundle\Utility\DtoReflectionHelper;
 use PHPUnit\Framework\MockObject\Exception;
 use PHPUnit\Framework\MockObject\MockObject;
 use PHPUnit\Framework\TestCase;

--- a/test/Unit/Validator/GroupSequenceExtractorTest.php
+++ b/test/Unit/Validator/GroupSequenceExtractorTest.php
@@ -1,0 +1,175 @@
+<?php
+
+/*
+ * This file is part of a private project.
+ *
+ * Copyright 2026 Crtl
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+declare(strict_types=1);
+
+namespace Crtl\RequestDtoResolverBundle\Test\Unit\Validator;
+
+use Crtl\RequestDtoResolverBundle\Validator\GroupSequenceExtractor;
+use PHPUnit\Framework\TestCase;
+use Psr\Container\ContainerInterface;
+use Symfony\Component\Validator\Constraint;
+use Symfony\Component\Validator\Constraints\GroupSequence;
+use Symfony\Component\Validator\GroupProviderInterface;
+use Symfony\Component\Validator\GroupSequenceProviderInterface;
+use Symfony\Component\Validator\Mapping\ClassMetadataInterface;
+
+final class GroupSequenceExtractorTest extends TestCase
+{
+    public function testGetGroupSequenceReturnsGroupsIfDefaultNotInGroups(): void
+    {
+        $extractor = new GroupSequenceExtractor();
+        $object = new \stdClass();
+        $groups = ['CustomGroup'];
+        $metadata = $this->createMock(ClassMetadataInterface::class);
+        $metadata->method('getClassName')->willReturn(\stdClass::class);
+
+        $result = $extractor->getGroupSequence($object, $groups, $metadata);
+
+        $this->assertEquals($groups, $result);
+    }
+
+    public function testGetGroupSequenceReturnsGroupsIfClassNameNotInGroups(): void
+    {
+        $extractor = new GroupSequenceExtractor();
+        $object = new \stdClass();
+        $groups = [Constraint::DEFAULT_GROUP];
+        $metadata = $this->createMock(ClassMetadataInterface::class);
+        $metadata->method('getClassName')->willReturn('SomeOtherClass');
+
+        $result = $extractor->getGroupSequence($object, $groups, $metadata);
+
+        $this->assertEquals($groups, $result);
+    }
+
+    public function testGetGroupSequenceReturnsStaticSequenceFromMetadata(): void
+    {
+        $extractor = new GroupSequenceExtractor();
+        $object = new \stdClass();
+        $className = \stdClass::class;
+        $groups = [$className, Constraint::DEFAULT_GROUP];
+        $sequence = new GroupSequence(['Group1', 'Group2']);
+
+        $metadata = $this->createMock(ClassMetadataInterface::class);
+        $metadata->method('getClassName')->willReturn($className);
+        $metadata->method('hasGroupSequence')->willReturn(true);
+        $metadata->method('getGroupSequence')->willReturn($sequence);
+
+        $result = $extractor->getGroupSequence($object, $groups, $metadata);
+
+        $this->assertSame($sequence, $result);
+    }
+
+    public function testGetGroupSequenceReturnsSequenceFromGroupSequenceProviderInterface(): void
+    {
+        $extractor = new GroupSequenceExtractor();
+        $object = $this->createMock(GroupSequenceProviderInterface::class);
+        $className = get_class($object);
+        $groups = [$className, Constraint::DEFAULT_GROUP];
+        $sequence = ['Group1', 'Group2'];
+
+        $object->method('getGroupSequence')->willReturn($sequence);
+
+        $metadata = $this->createMock(ClassMetadataInterface::class);
+        $metadata->method('getClassName')->willReturn($className);
+        $metadata->method('hasGroupSequence')->willReturn(false);
+        $metadata->method('isGroupSequenceProvider')->willReturn(true);
+
+        // @phpstan-ignore function.alreadyNarrowedType
+        if (method_exists($metadata, 'getGroupProvider')) {
+            $metadata->method('getGroupProvider')->willReturn(null);
+        }
+
+        $result = $extractor->getGroupSequence($object, $groups, $metadata);
+
+        $this->assertInstanceOf(GroupSequence::class, $result);
+        $this->assertEquals($sequence, $result->groups);
+    }
+
+    public function testGetGroupSequenceReturnsSequenceFromGroupProviderInterfaceViaLocator(): void
+    {
+        // @phpstan-ignore function.alreadyNarrowedType
+        if (!method_exists(ClassMetadataInterface::class, 'getGroupProvider')) {
+            self::markTestSkipped('External GroupProviderInterface not available');
+        }
+
+        $locator = $this->createMock(ContainerInterface::class);
+        $extractor = new GroupSequenceExtractor($locator);
+
+        $object = new \stdClass();
+        $className = \stdClass::class;
+        $groups = [$className, Constraint::DEFAULT_GROUP];
+        $providerClass = 'App\Validator\MyGroupProvider';
+        $sequence = ['GroupA', 'GroupB'];
+
+        $metadata = $this->createMock(ClassMetadataInterface::class);
+        $metadata->method('getClassName')->willReturn($className);
+        $metadata->method('hasGroupSequence')->willReturn(false);
+        $metadata->method('isGroupSequenceProvider')->willReturn(true);
+        $metadata->method('getGroupProvider')->willReturn($providerClass);
+
+        $provider = $this->createMock(GroupProviderInterface::class);
+        $provider->method('getGroups')->with($object)->willReturn($sequence);
+
+        $locator->method('get')->with($providerClass)->willReturn($provider);
+
+        $result = $extractor->getGroupSequence($object, $groups, $metadata);
+
+        $this->assertInstanceOf(GroupSequence::class, $result);
+        $this->assertEquals($sequence, $result->groups);
+    }
+
+    public function testGetGroupSequenceThrowsLogicExceptionWhenLocatorIsMissing(): void
+    {
+        // @phpstan-ignore function.alreadyNarrowedType
+        if (!method_exists(ClassMetadataInterface::class, 'getGroupProvider')) {
+            self::markTestSkipped('External GroupProviderInterface not available');
+        }
+
+        $extractor = new GroupSequenceExtractor(null);
+
+        $object = new \stdClass();
+        $className = \stdClass::class;
+        $groups = [$className, Constraint::DEFAULT_GROUP];
+        $providerClass = 'App\Validator\MyGroupProvider';
+
+        $metadata = $this->createMock(ClassMetadataInterface::class);
+        $metadata->method('getClassName')->willReturn($className);
+        $metadata->method('hasGroupSequence')->willReturn(false);
+        $metadata->method('isGroupSequenceProvider')->willReturn(true);
+        // @phpstan-ignore function.alreadyNarrowedType
+        if (method_exists($metadata, 'getGroupProvider')) {
+            $metadata->method('getGroupProvider')->willReturn($providerClass);
+        }
+
+        $this->expectException(\LogicException::class);
+        $this->expectExceptionMessage('A group provider locator is required when using group provider.');
+
+        $extractor->getGroupSequence($object, $groups, $metadata);
+    }
+
+    public function testGetGroupSequenceReturnsGroupsIfNoSequenceOrProviderDefined(): void
+    {
+        $extractor = new GroupSequenceExtractor();
+        $object = new \stdClass();
+        $className = \stdClass::class;
+        $groups = [$className, Constraint::DEFAULT_GROUP];
+
+        $metadata = $this->createMock(ClassMetadataInterface::class);
+        $metadata->method('getClassName')->willReturn($className);
+        $metadata->method('hasGroupSequence')->willReturn(false);
+        $metadata->method('isGroupSequenceProvider')->willReturn(false);
+
+        $result = $extractor->getGroupSequence($object, $groups, $metadata);
+
+        $this->assertEquals($groups, $result);
+    }
+}


### PR DESCRIPTION
- Add support for arrays of nested DTOs described via phpdoc
- Add full support for group sequence providers (introduce GroupSequenceExtractor, wire into RequestDtoValidator, add RequestDtoTrait)
- Register RequestValidationEventSubscriber and adjust its priority to -32
- Add/adjust integration tests and improve documentation (including limitations around nested DTO constraints)
- Update tooling/config (phpstan memory limit) and apply code style fixes

BREAKING CHANGE: Namespace renamed to `Crtl\RequestDtoResolverBundle` and property info extractor configuration updated.

## Description

*Please include a summary of the changes and the related issue.*

Closes #...

## What type of PR is this? (check all applicable)
- [ ] Bug Fix
- [x] Feature
- [x] Refactor
- [x] Deprecation
- [x] Breaking Change
- [x] Documentation Update
- [ ] CI

## Checklist
- [x] I have made corresponding changes to the documentation